### PR TITLE
fix a missing return in OreGenerator

### DIFF
--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/OreGenerator.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/OreGenerator.java
@@ -177,6 +177,7 @@ public class OreGenerator implements IGenerator {
                 return;
             } else {
                 dropItem(location);
+                return;
             }
         }
         lastSpawn--;


### PR DESCRIPTION
without this **return** statement, **lastSpawn** counter will keep going down into negative after item drop if **enable-gen-split** is disabled and **delay** is set to 0, so new resources will not spawn anymore