### PR TITLE
Added Redis support for BedWars1058 Bungee mode

### DIFF
--- a/bedwars-api/src/main/java/com/andrei1058/bedwars/api/configuration/ConfigPath.java
+++ b/bedwars-api/src/main/java/com/andrei1058/bedwars/api/configuration/ConfigPath.java
@@ -272,4 +272,12 @@ public class ConfigPath {
     public static final String SHOP_PATH_CATEGORY_UTILITY = "utility-category";
 
     public static final String TEAM_NAME_PATH = "team-name-{arena}-{team}";
+
+    public static final String REDIS_ENABLED = "redis.enabled";
+    public static final String REDIS_HOST = "redis.host";
+    public static final String REDIS_PORT = "redis.port";
+    public static final String REDIS_CHANNEL = "redis.channel";
+    public static final String REDIS_AUTH_USERNAME = "redis.auth.username";
+    public static final String REDIS_AUTH_PASSWORD = "redis.auth.password";
+
 }

--- a/bedwars-plugin/pom.xml
+++ b/bedwars-plugin/pom.xml
@@ -214,6 +214,18 @@
             <version>1.7.30</version>
             <optional>true</optional>
         </dependency>
+        <!-- Jedis Client -->
+        <dependency>
+            <groupId>redis.clients</groupId>
+            <artifactId>jedis</artifactId>
+            <version>3.7.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>RELEASE</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/BedWars.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/BedWars.java
@@ -58,6 +58,8 @@ import com.andrei1058.bedwars.lobbysocket.ArenaSocket;
 import com.andrei1058.bedwars.lobbysocket.LoadedUsersCleaner;
 import com.andrei1058.bedwars.lobbysocket.SendTask;
 import com.andrei1058.bedwars.maprestore.internal.InternalAdapter;
+import com.andrei1058.bedwars.redis.RedisArenaListeners;
+import com.andrei1058.bedwars.redis.RedisConnection;
 import com.andrei1058.bedwars.shop.ShopManager;
 import com.andrei1058.bedwars.sidebar.*;
 import com.andrei1058.bedwars.stats.StatsManager;
@@ -115,6 +117,8 @@ public class BedWars extends JavaPlugin {
     private static Economy economy;
     private static final String version = Bukkit.getServer().getClass().getName().split("\\.")[3];
     private static String lobbyWorld = "";
+
+    private static RedisConnection redisConnection;
 
     public static ArenaManager arenaManager = new ArenaManager();
 
@@ -287,11 +291,22 @@ public class BedWars extends JavaPlugin {
         registerEvents(new QuitAndTeleportListener(), new BreakPlace(), new DamageDeathMove(), new Inventory(), new Interact(), new RefreshGUI(), new HungerWeatherSpawn(), new CmdProcess(),
                 new EggBridge(), new SpectatorListeners(), new BaseListener(), new TargetListener(), new LangListener());
         if (getServerType() == ServerType.BUNGEE) {
+            boolean isRedis = config.getBoolean(ConfigPath.REDIS_ENABLED);
             if (autoscale) {
                 //registerEvents(new ArenaListeners());
-                ArenaSocket.lobbies.addAll(config.getList(ConfigPath.GENERAL_CONFIGURATION_BUNGEE_OPTION_LOBBY_SERVERS));
-                new SendTask();
-                registerEvents(new AutoscaleListener(), new PrePartyListener(), new JoinListenerBungee());
+                if(isRedis) {
+                    redisConnection = new RedisConnection();
+                    if(!redisConnection.connect()) {
+                        getLogger().log(java.util.logging.Level.SEVERE, "Failed to connect to redis, please check redis config. Disabling the plugin...");
+                        setEnabled(false);
+                        return;
+                    }
+                    registerEvents(new RedisArenaListeners(redisConnection), new JoinListenerBungee());
+                } else {
+                    ArenaSocket.lobbies.addAll(config.getList(ConfigPath.GENERAL_CONFIGURATION_BUNGEE_OPTION_LOBBY_SERVERS));
+                    new SendTask();
+                    registerEvents(new AutoscaleListener(), new PrePartyListener(), new JoinListenerBungee());
+                }
                 Bukkit.getScheduler().runTaskTimerAsynchronously(this, new LoadedUsersCleaner(), 60L, 60L);
             } else {
                 registerEvents(new ServerPingListener(), new JoinListenerBungeeLegacy());

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/configuration/MainConfig.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/configuration/MainConfig.java
@@ -109,6 +109,13 @@ public class MainConfig extends ConfigManager {
         yml.addDefault("database.pass", "cheese");
         yml.addDefault("database.ssl", false);
 
+        yml.addDefault(ConfigPath.REDIS_ENABLED, false);
+        yml.addDefault(ConfigPath.REDIS_HOST, "localhost");
+        yml.addDefault(ConfigPath.REDIS_PORT, 6379);
+        yml.addDefault(ConfigPath.REDIS_CHANNEL, "bw1058_arenas");
+        yml.addDefault(ConfigPath.REDIS_AUTH_USERNAME, "redisUser");
+        yml.addDefault(ConfigPath.REDIS_AUTH_PASSWORD, "changeThisValuePlx");
+
         yml.addDefault(ConfigPath.GENERAL_CONFIGURATION_PERFORMANCE_ROTATE_GEN, true);
         yml.addDefault(ConfigPath.GENERAL_CONFIGURATION_PERFORMANCE_SPOIL_TNT_PLAYERS, true);
 

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/lobbysocket/ArenaSocket.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/lobbysocket/ArenaSocket.java
@@ -150,7 +150,6 @@ public class ArenaSocket {
                                         jo.addProperty("requester", json.get("requester").getAsString());
                                         jo.addProperty("server_name", BedWars.config.getString(ConfigPath.GENERAL_CONFIGURATION_BUNGEE_OPTION_SERVER_ID));
                                         jo.addProperty("arena_id", a.getWorldName());
-                                        out.println(jo.toString());
                                     }
                                 }
                                 break;

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/lobbysocket/LoadedUsersCleaner.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/lobbysocket/LoadedUsersCleaner.java
@@ -41,7 +41,7 @@ public class LoadedUsersCleaner implements Runnable {
         if (!toRemove.isEmpty()) {
             toRemove.forEach(c -> {
                 OfflinePlayer op = Bukkit.getOfflinePlayer(c.getUuid());
-                if (op != null && op.getName() != null) {
+                if (op.getName() != null) {
                     PreLoadedParty plp = PreLoadedParty.getPartyByOwner(op.getName());
                     if (plp != null) {
                         plp.clean();

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/redis/RedisArenaListeners.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/redis/RedisArenaListeners.java
@@ -1,0 +1,49 @@
+package com.andrei1058.bedwars.redis;
+
+import com.andrei1058.bedwars.BedWars;
+import com.andrei1058.bedwars.api.arena.IArena;
+import com.andrei1058.bedwars.api.events.gameplay.GameStateChangeEvent;
+import com.andrei1058.bedwars.api.events.player.PlayerJoinArenaEvent;
+import com.andrei1058.bedwars.api.events.player.PlayerLeaveArenaEvent;
+import com.andrei1058.bedwars.api.events.server.ArenaEnableEvent;
+import com.andrei1058.bedwars.lobbysocket.ArenaSocket;
+import org.bukkit.Bukkit;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+public class RedisArenaListeners implements Listener {
+
+    private final RedisConnection redisConnection;
+
+    public RedisArenaListeners(RedisConnection connection) {
+        this.redisConnection = connection;
+    }
+
+    @EventHandler
+    public void onPlayerJoinArena(PlayerJoinArenaEvent e) {
+        if (e == null) return;
+        final IArena a = e.getArena();
+        Bukkit.getScheduler().runTaskAsynchronously(BedWars.plugin, ()-> redisConnection.sendMessage(ArenaSocket.formatUpdateMessage(a)));
+    }
+
+    @EventHandler
+    public void onPlayerLeaveArena(PlayerLeaveArenaEvent e){
+        if (e == null) return;
+        final IArena a = e.getArena();
+        Bukkit.getScheduler().runTaskAsynchronously(BedWars.plugin, ()-> redisConnection.sendMessage(ArenaSocket.formatUpdateMessage(a)));
+    }
+
+    @EventHandler
+    public void onArenaStatusChange(GameStateChangeEvent e){
+        if (e == null) return;
+        final IArena a = e.getArena();
+        Bukkit.getScheduler().runTaskAsynchronously(BedWars.plugin, ()-> redisConnection.sendMessage(ArenaSocket.formatUpdateMessage(a)));
+    }
+
+    @EventHandler
+    public void onArenaLoad(ArenaEnableEvent e){
+        if (e == null) return;
+        final IArena a = e.getArena();
+        Bukkit.getScheduler().runTaskAsynchronously(BedWars.plugin, ()-> redisConnection.sendMessage(ArenaSocket.formatUpdateMessage(a)));
+    }
+}

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/redis/RedisConnection.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/redis/RedisConnection.java
@@ -1,0 +1,39 @@
+package com.andrei1058.bedwars.redis;
+
+import com.andrei1058.bedwars.BedWars;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+
+public class RedisConnection {
+
+    private final String host, username, password, channel;
+    private final int port;
+    private final JedisPool dataSource;
+    private final RedisListener listener;
+    private Jedis listenerConnection;
+
+    public RedisConnection() {
+        this.host = BedWars.config.getYml().getString("redis.host");
+        this.port = BedWars.config.getYml().getInt("redis.port");
+        this.channel = BedWars.config.getYml().getString("redis.channel");
+        this.username = BedWars.config.getYml().getString("redis.auth.username");
+        this.password = BedWars.config.getYml().getString("redis.auth.password");
+        this.dataSource = new JedisPool(host, port, username, password);
+        this.listener = new RedisListener(channel);
+    }
+
+    public boolean connect() {
+        this.listenerConnection = dataSource.getResource();
+        if(this.listenerConnection == null) {
+            return false;
+        }
+        this.listenerConnection.subscribe(listener, channel);
+        return true;
+    }
+
+    public void sendMessage(String message) {
+        this.listenerConnection.publish(channel, message);
+    }
+
+
+}

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/redis/RedisListener.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/redis/RedisListener.java
@@ -1,0 +1,55 @@
+package com.andrei1058.bedwars.redis;
+
+import com.andrei1058.bedwars.BedWars;
+import com.andrei1058.bedwars.api.arena.IArena;
+import com.andrei1058.bedwars.api.configuration.ConfigPath;
+import com.andrei1058.bedwars.arena.Arena;
+import com.andrei1058.bedwars.lobbysocket.LoadedUser;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import redis.clients.jedis.JedisPubSub;
+
+import java.util.logging.Level;
+
+public class RedisListener extends JedisPubSub {
+    private final String BW_CHANNEL;
+    public RedisListener(String channel) {
+        this.BW_CHANNEL = channel;
+    }
+    @Override
+    public void onMessage(String channel, String message) {
+        if(channel.equals(BW_CHANNEL)) {
+            final JsonObject json;
+            try {
+                json = new JsonParser().parse(message).getAsJsonObject();
+            } catch (JsonSyntaxException e) {
+                BedWars.plugin.getLogger().log(Level.WARNING, "Received bad data from redis message channel " + BW_CHANNEL);
+                return;
+            }
+            if (json == null) return;
+            if (!json.has("type")) return;
+            switch (json.get("type").getAsString().toUpperCase()) {
+                case "PLD":
+                    new LoadedUser(json.get("uuid").getAsString(), json.get("arena_identifier").getAsString(), json.get("lang_iso").getAsString(), json.get("target").getAsString());
+                    break;
+                case "Q":
+                    Player p = Bukkit.getPlayer(json.get("name").getAsString());
+                    if (p != null && p.isOnline()){
+                        IArena a = Arena.getArenaByPlayer(p);
+                        if (a != null) {
+                            JsonObject jo = new JsonObject();
+                            jo.addProperty("type", "Q");
+                            jo.addProperty("name", p.getName());
+                            jo.addProperty("requester", json.get("requester").getAsString());
+                            jo.addProperty("server_name", BedWars.config.getString(ConfigPath.GENERAL_CONFIGURATION_BUNGEE_OPTION_SERVER_ID));
+                            jo.addProperty("arena_id", a.getWorldName());
+                        }
+                    }
+                    break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implemented redis support with BedWars1058 so if you want to use redis instead of sockets just enable redis at config.yml