### PR TITLE
fix generator skipping item drop

### DIFF
--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/OreGenerator.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/OreGenerator.java
@@ -187,7 +187,7 @@ public class OreGenerator implements IGenerator {
     }
 
     private void dropItem(Location location, int amount) {
-        for (int temp = amount; temp >= 0; temp--) {
+        for (int temp = amount; temp > 0; temp--) {
             ItemStack itemStack = new ItemStack(ore);
             if (!stack) {
                 ItemMeta itemMeta = itemStack.getItemMeta();
@@ -196,7 +196,6 @@ public class OreGenerator implements IGenerator {
             }
             Item item = location.getWorld().dropItem(location, itemStack);
             item.setVelocity(new Vector(0, 0, 0));
-            temp--; // FIXME: why is this required? something must be wrong...
         }
     }
 


### PR DESCRIPTION
### Identify the Bug
**Iron and Gold generators** don't drop the correct amount of items
**For example** if you set in config `amount: 3` then it will only drop **2** items
and if you set in config `amount: 5` then it will only drop **3** items

This bug is caused by an extra line in **OreGenerator** class **dropItem** method 
`temp--;`
We don't need that extra line because the loop's logic is flawed:
`temp = amount` as the starting statement will set temp variable to the amount we want
`temp >= 0` as the ending condition will make it spawn an extra item because when **temp** variable is at zero, the loop still continues one more time
### Description of the Change
Set the loop's ending condition to `temp > 0` will make the loop stop when the correct amount of items have been spawned, so we don't need that extra line anymore