### PR TITLE
Fix dark and light grays not being named correctly

### DIFF
--- a/bedwars-api/src/main/java/com/andrei1058/bedwars/api/arena/team/TeamColor.java
+++ b/bedwars-api/src/main/java/com/andrei1058/bedwars/api/arena/team/TeamColor.java
@@ -289,10 +289,10 @@ public enum TeamColor {
                 name = "White";
                 break;
             case 8:
-                name = "Gray";
+                name = "Dark_Gray";
                 break;
             case 7:
-                name = "lGray";
+                name = "Gray";
                 break;
 
         }

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/commands/bedwars/subcmds/sensitive/setup/AutoCreateTeams.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/commands/bedwars/subcmds/sensitive/setup/AutoCreateTeams.java
@@ -209,7 +209,7 @@ public class AutoCreateTeams extends SubCommand {
                     p.sendMessage("§6§lNEW TEAMS FOUND:");
                     for (Byte tf : found) {
                         String name = TeamColor.enName(tf);
-                        p.sendMessage("§f ▪ " + TeamColor.getChatColor(name) + name);
+                        p.sendMessage("§f ▪ " + TeamColor.getChatColor(name) + name.replace('_', ' '));
                     }
                     p.spigot().sendMessage(Misc.msgHoverClick("§6 ▪ §7§lClick here to create found teams.", "§fClick to create found teams!", "/" + getParent().getName() + " " + getSubCommandName(), ClickEvent.Action.RUN_COMMAND));
                 }


### PR DESCRIPTION
Fix dark and light grays not being named correctly.

Fixes #54 