### PR TITLE
Added {playername} placeholder support to messages

### DIFF
--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/Arena.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/Arena.java
@@ -493,7 +493,7 @@ public class Arena implements IArena {
             p.setFlying(false);
             p.setAllowFlight(false);
             for (Player on : players) {
-                on.sendMessage(getMsg(on, Messages.COMMAND_JOIN_PLAYER_JOIN_MSG).replace("{player}", p.getDisplayName()).replace("{on}", String.valueOf(getPlayers().size())).replace("{max}", String.valueOf(getMaxPlayers())));
+                on.sendMessage(getMsg(on, Messages.COMMAND_JOIN_PLAYER_JOIN_MSG).replace("{playername}", p.getName()).replace("{player}", p.getDisplayName()).replace("{on}", String.valueOf(getPlayers().size())).replace("{max}", String.valueOf(getMaxPlayers())));
             }
             setArenaByPlayer(p, this);
 
@@ -847,10 +847,10 @@ public class Arena implements IArena {
             }
         }
         for (Player on : getPlayers()) {
-            on.sendMessage(getMsg(on, Messages.COMMAND_LEAVE_MSG).replace("{player}", p.getDisplayName()));
+            on.sendMessage(getMsg(on, Messages.COMMAND_LEAVE_MSG).replace("{playername}", p.getName()).replace("{player}", p.getDisplayName()));
         }
         for (Player on : getSpectators()) {
-            on.sendMessage(getMsg(on, Messages.COMMAND_LEAVE_MSG).replace("{player}", p.getDisplayName()));
+            on.sendMessage(getMsg(on, Messages.COMMAND_LEAVE_MSG).replace("{playername}", p.getName()).replace("{player}", p.getDisplayName()));
         }
 
         if (getServerType() == ServerType.SHARED) {
@@ -1097,10 +1097,10 @@ public class Arena implements IArena {
         p.closeInventory();
         players.add(p);
         for (Player on : players) {
-            on.sendMessage(getMsg(on, Messages.COMMAND_REJOIN_PLAYER_RECONNECTED).replace("{player}", p.getDisplayName()).replace("{on}", String.valueOf(getPlayers().size())).replace("{max}", String.valueOf(getMaxPlayers())));
+            on.sendMessage(getMsg(on, Messages.COMMAND_REJOIN_PLAYER_RECONNECTED).replace("{playername}", p.getName()).replace("{player}", p.getDisplayName()).replace("{on}", String.valueOf(getPlayers().size())).replace("{max}", String.valueOf(getMaxPlayers())));
         }
         for (Player on : spectators) {
-            on.sendMessage(getMsg(on, Messages.COMMAND_REJOIN_PLAYER_RECONNECTED).replace("{player}", p.getDisplayName()).replace("{on}", String.valueOf(getPlayers().size())).replace("{max}", String.valueOf(getMaxPlayers())));
+            on.sendMessage(getMsg(on, Messages.COMMAND_REJOIN_PLAYER_RECONNECTED).replace("{playername}", p.getName()).replace("{player}", p.getDisplayName()).replace("{on}", String.valueOf(getPlayers().size())).replace("{max}", String.valueOf(getMaxPlayers())));
         }
         setArenaByPlayer(p, this);
         /* save player inventory etc */

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/Misc.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/Misc.java
@@ -334,6 +334,7 @@ public class Misc {
         if (s.contains("{lastPlay}"))
             s = s.replace("{lastPlay}", new SimpleDateFormat(getMsg(player, Messages.FORMATTING_STATS_DATE_FORMAT)).format(stats.getLastPlay() != null ? Timestamp.from(stats.getLastPlay()) : Timestamp.from(Instant.now())));
         if (s.contains("{player}")) s = s.replace("{player}", player.getDisplayName());
+        if (s.contains("{playername")) s = s.replace("{playername}", player.getName());
         if (s.contains("{prefix}")) s = s.replace("{prefix}", BedWars.getChatSupport().getPrefix(player));
 
         return papiReplacements ? SupportPAPI.getSupportPAPI().replace(player, s) : s;

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/spectator/SpectatorListeners.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/spectator/SpectatorListeners.java
@@ -177,7 +177,7 @@ public class SpectatorListeners implements Listener {
             p.getInventory().setHeldItemSlot(5);
             p.setGameMode(GameMode.SPECTATOR);
             p.setSpectatorTarget(target);
-            nms.sendTitle(p, event.getTitle().apply(p).replace("{player}", target.getDisplayName()), event.getSubTitle().apply(p).replace("{player}", target.getDisplayName()), event.getFadeIn(), event.getStay(), event.getFadeOut());
+            nms.sendTitle(p, event.getTitle().apply(p).replace("{playername}", p.getName()).replace("{player}", target.getDisplayName()), event.getSubTitle().apply(p).replace("{player}", target.getDisplayName()), event.getFadeIn(), event.getStay(), event.getFadeOut());
         }
     }
 

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/spectator/TeleporterGUI.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/spectator/TeleporterGUI.java
@@ -120,7 +120,8 @@ public class TeleporterGUI {
         im.setDisplayName(getMsg(GUIholder, Messages.ARENA_SPECTATOR_TELEPORTER_GUI_HEAD_NAME)
                 .replace("{prefix}", BedWars.getChatSupport().getPrefix(targetPlayer))
                 .replace("{suffix}", BedWars.getChatSupport().getSuffix(targetPlayer))
-                        .replace("{player}", targetPlayer.getDisplayName()));
+                .replace("{player}", targetPlayer.getDisplayName())
+                .replace("{playername}", targetPlayer.getName()));
         List<String> lore = new ArrayList<>();
         String health = String.valueOf((int)targetPlayer.getHealth() * 100 / targetPlayer.getHealthScale());
         for (String s : getList(GUIholder, Messages.ARENA_SPECTATOR_TELEPORTER_GUI_HEAD_LORE)) {

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/commands/party/PartyCommand.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/commands/party/PartyCommand.java
@@ -68,7 +68,7 @@ public class PartyCommand extends BukkitCommand {
                         p.sendMessage(getMsg(p, Messages.COMMAND_PARTY_INVITE_DENIED_CANNOT_INVITE_YOURSELF));
                         return true;
                     }
-                    p.sendMessage(getMsg(p, Messages.COMMAND_PARTY_INVITE_SENT).replace("{player}", args[1]));
+                    p.sendMessage(getMsg(p, Messages.COMMAND_PARTY_INVITE_SENT).replace("{playername}", p.getName()).replace("{player}", args[1]));
                     TextComponent tc = new TextComponent(getMsg(p, Messages.COMMAND_PARTY_INVITE_SENT_TARGET_RECEIVE_MSG).replace("{player}", p.getName()));
                     tc.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/party accept " + p.getName()));
                     Bukkit.getPlayer(args[1]).spigot().sendMessage(tc);
@@ -102,12 +102,12 @@ public class PartyCommand extends BukkitCommand {
                     if (getParty().hasParty(Bukkit.getPlayer(args[1]))) {
                         getParty().addMember(Bukkit.getPlayer(args[1]), p);
                         for (Player on : getParty().getMembers(Bukkit.getPlayer(args[1]))) {
-                            on.sendMessage(getMsg(p, Messages.COMMAND_PARTY_ACCEPT_SUCCESS).replace("{player}", p.getDisplayName()));
+                            on.sendMessage(getMsg(p, Messages.COMMAND_PARTY_ACCEPT_SUCCESS).replace("{playername}", p.getName()).replace("{player}", p.getDisplayName()));
                         }
                     } else {
                         getParty().createParty(Bukkit.getPlayer(args[1]), p);
                         for (Player on : getParty().getMembers(Bukkit.getPlayer(args[1]))) {
-                            on.sendMessage(getMsg(p, Messages.COMMAND_PARTY_ACCEPT_SUCCESS).replace("{player}", p.getDisplayName()));
+                            on.sendMessage(getMsg(p, Messages.COMMAND_PARTY_ACCEPT_SUCCESS).replace("{playername}", p.getName()).replace("{player}", p.getDisplayName()));
                         }
                     }
                 } else {

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/Inventory.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/Inventory.java
@@ -164,7 +164,7 @@ public class Inventory implements Listener {
         if (a != null) {
 
             //Prevent players from moving items in stats GUI
-            if (nms.getInventoryName(e).equals(Language.getMsg(p, Messages.PLAYER_STATS_GUI_INV_NAME).replace("{player}", p.getDisplayName()))) {
+            if (nms.getInventoryName(e).equals(Language.getMsg(p, Messages.PLAYER_STATS_GUI_INV_NAME).replace("{playername}", p.getName()).replace("{player}", p.getDisplayName()))) {
                 e.setCancelled(true);
                 return;
             }

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/PlayerChat.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/PlayerChat.java
@@ -63,7 +63,7 @@ public class PlayerChat implements Listener {
                 e.getRecipients().addAll(p.getWorld().getPlayers());
             }
             e.setFormat(SupportPAPI.getSupportPAPI().replace(e.getPlayer(), getMsg(p, Messages.FORMATTING_CHAT_LOBBY).replace("{vPrefix}", getChatSupport().getPrefix(p)).replace("{vSuffix}", getChatSupport().getSuffix(p))
-                    .replace("{player}", p.getDisplayName()).replace("{level}", getLevelSupport().getLevel(p))).replace("{message}", "%2$s"));
+                    .replace("{playername}", p.getName()).replace("{player}", p.getDisplayName()).replace("{level}", getLevelSupport().getLevel(p))).replace("{message}", "%2$s"));
         } else if (Arena.getArenaByPlayer(p) != null) {
             IArena a = Arena.getArenaByPlayer(p);
             Arena.afkCheck.remove(p.getUniqueId());
@@ -76,7 +76,7 @@ public class PlayerChat implements Listener {
                     e.getRecipients().addAll(a.getSpectators());
                 }
                 e.setFormat(SupportPAPI.getSupportPAPI().replace(e.getPlayer(), getMsg(p, Messages.FORMATTING_CHAT_SPECTATOR).replace("{vPrefix}", getChatSupport().getPrefix(p)).replace("{vSuffix}", getChatSupport().getSuffix(p))
-                        .replace("{player}", p.getDisplayName()).replace("{message}", "%2$s").replace("{level}", getLevelSupport().getLevel(p))));
+                        .replace("{playername}", p.getName()).replace("{player}", p.getDisplayName()).replace("{message}", "%2$s").replace("{level}", getLevelSupport().getLevel(p))));
             } else {
                 if (a.getStatus() == GameState.waiting || a.getStatus() == GameState.starting) {
                     if (!config.getBoolean("globalChat")) {
@@ -84,7 +84,7 @@ public class PlayerChat implements Listener {
                         e.getRecipients().addAll(a.getPlayers());
                     }
                     e.setFormat(SupportPAPI.getSupportPAPI().replace(e.getPlayer(), getMsg(p, Messages.FORMATTING_CHAT_WAITING).replace("{vPrefix}", getChatSupport().getPrefix(p)).replace("{vSuffix}", getChatSupport().getSuffix(p))
-                            .replace("{player}", p.getDisplayName()).replace("{level}", getLevelSupport().getLevel(p))).replace("{message}", "%2$s"));
+                            .replace("{playername}", p.getName()).replace("{player}", p.getDisplayName()).replace("{level}", getLevelSupport().getLevel(p))).replace("{message}", "%2$s"));
                     return;
                 }
                 ITeam t = a.getTeam(p);
@@ -117,7 +117,7 @@ public class PlayerChat implements Listener {
                     }
                     e.setMessage(msg);
                     e.setFormat(SupportPAPI.getSupportPAPI().replace(e.getPlayer(), getMsg(p, Messages.FORMATTING_CHAT_SHOUT).replace("{vPrefix}", getChatSupport().getPrefix(p)).replace("{vSuffix}", getChatSupport().getSuffix(p))
-                            .replace("{player}", p.getDisplayName()).replace("{team}", t.getColor().chat() + "[" + t.getDisplayName(Language.getPlayerLanguage(e.getPlayer())).toUpperCase() + "]")
+                            .replace("{playername}", p.getName()).replace("{player}", p.getDisplayName()).replace("{team}", t.getColor().chat() + "[" + t.getDisplayName(Language.getPlayerLanguage(e.getPlayer())).toUpperCase() + "]")
                             .replace("{level}", getLevelSupport().getLevel(p))).replace("{message}", "%2$s"));
                 } else {
                     if (a.getMaxInTeam() == 1) {
@@ -127,7 +127,7 @@ public class PlayerChat implements Listener {
                             e.getRecipients().addAll(a.getSpectators());
                         }
                         e.setFormat(SupportPAPI.getSupportPAPI().replace(e.getPlayer(), getMsg(p, Messages.FORMATTING_CHAT_TEAM).replace("{vPrefix}", getChatSupport().getPrefix(p)).replace("{vSuffix}", getChatSupport().getSuffix(p))
-                                .replace("{player}", p.getDisplayName()).replace("{team}", t.getColor().chat() + "[" + t.getDisplayName(Language.getPlayerLanguage(e.getPlayer())).toUpperCase() + "]")
+                                .replace("{playername}", p.getName()).replace("{player}", p.getDisplayName()).replace("{team}", t.getColor().chat() + "[" + t.getDisplayName(Language.getPlayerLanguage(e.getPlayer())).toUpperCase() + "]")
                                 .replace("{level}", getLevelSupport().getLevel(p))).replace("{message}", "%2$s"));
 
                     } else {
@@ -136,7 +136,7 @@ public class PlayerChat implements Listener {
                             e.getRecipients().addAll(t.getMembers());
                         }
                         e.setFormat(SupportPAPI.getSupportPAPI().replace(e.getPlayer(), getMsg(p, Messages.FORMATTING_CHAT_TEAM).replace("{vPrefix}", getChatSupport().getPrefix(p)).replace("{vSuffix}", getChatSupport().getSuffix(p))
-                                .replace("{player}", p.getDisplayName()).replace("{team}", t.getColor().chat() + "[" + t.getDisplayName(Language.getPlayerLanguage(e.getPlayer())).toUpperCase() + "]")
+                                .replace("{playername}", p.getName()).replace("{player}", p.getDisplayName()).replace("{team}", t.getColor().chat() + "[" + t.getDisplayName(Language.getPlayerLanguage(e.getPlayer())).toUpperCase() + "]")
                                 .replace("{level}", getLevelSupport().getLevel(p))).replace("{message}", "%2$s"));
 
                     }

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/sidebar/BedWarsScoreboard.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/sidebar/BedWarsScoreboard.java
@@ -286,6 +286,7 @@ public class BedWarsScoreboard {
                     .replace("{server_ip}", BedWars.config.getString(ConfigPath.GENERAL_CONFIG_PLACEHOLDERS_REPLACEMENTS_SERVER_IP))
                     .replace("{version}", plugin.getDescription().getVersion())
                     .replace("{server}", config.getString(ConfigPath.GENERAL_CONFIGURATION_BUNGEE_OPTION_SERVER_ID))
+                    .replace("{playername}", player.getName())
                     .replace("{player}", player.getDisplayName())
                     .replace("{money}", String.valueOf(getEconomy().getMoney(player)));
 

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/support/party/Internal.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/support/party/Internal.java
@@ -99,7 +99,7 @@ public class Internal implements Party {
                 disband(member);
             } else if (p.members.contains(member)) {
                 for (Player mem : p.members) {
-                    mem.sendMessage(getMsg(mem, Messages.COMMAND_PARTY_LEAVE_SUCCESS).replace("{player}", member.getDisplayName()));
+                    mem.sendMessage(getMsg(mem, Messages.COMMAND_PARTY_LEAVE_SUCCESS).replace("{playername}", member.getName()).replace("{player}", member.getDisplayName()));
                 }
                 p.members.remove(member);
                 if (p.members.isEmpty() || p.members.size() == 1) {

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/upgrades/menu/MenuBaseTrap.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/upgrades/menu/MenuBaseTrap.java
@@ -278,7 +278,7 @@ public class MenuBaseTrap implements MenuContent, EnemyBaseEnterTrap, TeamUpgrad
         Sounds.playSound(ConfigPath.SOUNDS_BOUGHT, player);
         team.getActiveTraps().add(this);
         for (Player p1 : team.getMembers()) {
-            p1.sendMessage(Language.getMsg(p1, Messages.UPGRADES_UPGRADE_BOUGHT_CHAT).replace("{player}", player.getDisplayName()).replace("{upgradeName}",
+            p1.sendMessage(Language.getMsg(p1, Messages.UPGRADES_UPGRADE_BOUGHT_CHAT).replace("{playername}", player.getName()).replace("{player}", player.getDisplayName()).replace("{upgradeName}",
                     ChatColor.stripColor(Language.getMsg(p1, Messages.UPGRADES_BASE_TRAP_ITEM_NAME_PATH + getName().replace("base-trap-", "")).replace("{color}", ""))));
         }
         Bukkit.getPluginManager().callEvent(new UpgradeBuyEvent(this, player, team));

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/upgrades/menu/MenuSeparator.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/upgrades/menu/MenuSeparator.java
@@ -80,11 +80,11 @@ public class MenuSeparator implements MenuContent {
     public void onClick(Player player, ClickType clickType, ITeam team) {
         for (String cmd : playerCommands) {
             if (cmd.trim().isEmpty()) continue;
-            Bukkit.dispatchCommand(player, cmd.replace("{player}", player.getDisplayName()).replace("{team}", team == null ? "null" : team.getDisplayName(Language.getPlayerLanguage(player))));
+            Bukkit.dispatchCommand(player, cmd.replace("{playername}", player.getName()).replace("{player}", player.getDisplayName()).replace("{team}", team == null ? "null" : team.getDisplayName(Language.getPlayerLanguage(player))));
         }
         for (String cmd : consoleCommands) {
             if (cmd.trim().isEmpty()) continue;
-            Bukkit.dispatchCommand(Bukkit.getConsoleSender(), cmd.replace("{player}", player.getDisplayName()).replace("{team}", team == null ? "null" : team.getDisplayName(Language.getPlayerLanguage(player))));
+            Bukkit.dispatchCommand(Bukkit.getConsoleSender(), cmd.replace("{playername}", player.getName()).replace("{player}", player.getDisplayName()).replace("{team}", team == null ? "null" : team.getDisplayName(Language.getPlayerLanguage(player))));
         }
     }
 

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/upgrades/menu/MenuUpgrade.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/upgrades/menu/MenuUpgrade.java
@@ -146,7 +146,7 @@ public class MenuUpgrade implements MenuContent, TeamUpgrade {
             }
 
             for (Player p1 : team.getMembers()) {
-                p1.sendMessage(Language.getMsg(p1, Messages.UPGRADES_UPGRADE_BOUGHT_CHAT).replace("{player}", player.getDisplayName()).replace("{upgradeName}",
+                p1.sendMessage(Language.getMsg(p1, Messages.UPGRADES_UPGRADE_BOUGHT_CHAT).replace("{playername}", player.getName()).replace("{player}", player.getDisplayName()).replace("{upgradeName}",
                         ChatColor.stripColor(Language.getMsg(p1, Messages.UPGRADES_UPGRADE_TIER_ITEM_NAME.replace("{name}", getName()
                                 .replace("upgrade-", "")).replace("{tier}", ut.getName())))).replace("{color}", ""));
             }


### PR DESCRIPTION
Add `{playername}` placeholder to messages where `{player}` uses the display name

Some people want to show the players name only, not the display name.

I only added the placeholder to the places where the `{player}` placeholders uses the displayname. I left alone the ones where `{player}` already uses the normal player name.

Existing language configs should function the same.