### PR TITLE
Fix items not being removed from offhand

### DIFF
--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/PlayerChat.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/PlayerChat.java
@@ -97,7 +97,7 @@ public class PlayerChat implements Listener {
                     }
                     if (ShoutCommand.isShoutCooldown(p)){
                         e.setCancelled(true);
-                        p.sendMessage(Language.getMsg(p, Messages.COMMAND_COOLDOWN).replace("{seconds}", String.valueOf(ShoutCommand.getShoutCooldown(p))));
+                        p.sendMessage(Language.getMsg(p, Messages.COMMAND_COOLDOWN).replace("{seconds}", String.valueOf(Math.round(ShoutCommand.getShoutCooldown(p)))));
                         return;
                     }
                     ShoutCommand.updateShout(p);

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/PlayerChat.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/PlayerChat.java
@@ -97,7 +97,7 @@ public class PlayerChat implements Listener {
                     }
                     if (ShoutCommand.isShoutCooldown(p)){
                         e.setCancelled(true);
-                        p.sendMessage(Language.getMsg(p, Messages.COMMAND_COOLDOWN).replace("{seconds}", String.valueOf(Math.round(ShoutCommand.getShoutCooldown(p)))));
+                        p.sendMessage(Language.getMsg(p, Messages.COMMAND_COOLDOWN).replace("{seconds}", String.valueOf(ShoutCommand.getShoutCooldown(p))));
                         return;
                     }
                     ShoutCommand.updateShout(p);

--- a/versionsupport_1_10_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_10_R1/v1_10_R1.java
+++ b/versionsupport_1_10_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_10_R1/v1_10_R1.java
@@ -143,7 +143,11 @@ public class v1_10_R1 extends VersionSupport {
     @Override
     public void minusAmount(Player p, org.bukkit.inventory.ItemStack i, int amount) {
         if (i.getAmount() - amount <= 0) {
-            p.getInventory().removeItem(i);
+            if(p.getInventory().getItemInOffHand().equals(i)) {
+                p.getInventory().setItemInOffHand(null);
+            } else {
+                p.getInventory().removeItem(i);
+            }
             return;
         }
         i.setAmount(i.getAmount() - amount);

--- a/versionsupport_1_11_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_11_R1/v1_11_R1.java
+++ b/versionsupport_1_11_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_11_R1/v1_11_R1.java
@@ -147,7 +147,11 @@ public class v1_11_R1 extends VersionSupport {
     @Override
     public void minusAmount(Player p, org.bukkit.inventory.ItemStack i, int amount) {
         if (i.getAmount() - amount <= 0) {
-            p.getInventory().removeItem(i);
+            if(p.getInventory().getItemInOffHand().equals(i)) {
+                p.getInventory().setItemInOffHand(null);
+            } else {
+                p.getInventory().removeItem(i);
+            }
             return;
         }
         i.setAmount(i.getAmount() - amount);

--- a/versionsupport_1_12_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_12_R1/v1_12_R1.java
+++ b/versionsupport_1_12_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_12_R1/v1_12_R1.java
@@ -148,7 +148,11 @@ public class v1_12_R1 extends VersionSupport {
     @Override
     public void minusAmount(Player p, org.bukkit.inventory.ItemStack i, int amount) {
         if (i.getAmount() - amount <= 0) {
-            p.getInventory().removeItem(i);
+            if(p.getInventory().getItemInOffHand().equals(i)) {
+                p.getInventory().setItemInOffHand(null);
+            } else {
+                p.getInventory().removeItem(i);
+            }
             return;
         }
         i.setAmount(i.getAmount() - amount);

--- a/versionsupport_1_13_R2/src/main/java/com/andrei1058/bedwars/support/version/v1_13_R2/v1_13_R2.java
+++ b/versionsupport_1_13_R2/src/main/java/com/andrei1058/bedwars/support/version/v1_13_R2/v1_13_R2.java
@@ -149,7 +149,11 @@ public class v1_13_R2 extends VersionSupport {
     @Override
     public void minusAmount(Player p, org.bukkit.inventory.ItemStack i, int amount) {
         if (i.getAmount() - amount <= 0) {
-            p.getInventory().removeItem(i);
+            if(p.getInventory().getItemInOffHand().equals(i)) {
+                p.getInventory().setItemInOffHand(null);
+            } else {
+                p.getInventory().removeItem(i);
+            }
             return;
         }
         i.setAmount(i.getAmount() - amount);

--- a/versionsupport_1_14_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_14_R1/v1_14_R1.java
+++ b/versionsupport_1_14_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_14_R1/v1_14_R1.java
@@ -149,7 +149,11 @@ public class v1_14_R1 extends VersionSupport {
     @Override
     public void minusAmount(Player p, org.bukkit.inventory.ItemStack i, int amount) {
         if (i.getAmount() - amount <= 0) {
-            p.getInventory().removeItem(i);
+            if(p.getInventory().getItemInOffHand().equals(i)) {
+                p.getInventory().setItemInOffHand(null);
+            } else {
+                p.getInventory().removeItem(i);
+            }
             return;
         }
         i.setAmount(i.getAmount() - amount);

--- a/versionsupport_1_15_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_15_R1/v1_15_R1.java
+++ b/versionsupport_1_15_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_15_R1/v1_15_R1.java
@@ -148,7 +148,11 @@ public class v1_15_R1 extends VersionSupport {
     @Override
     public void minusAmount(Player p, org.bukkit.inventory.ItemStack i, int amount) {
         if (i.getAmount() - amount <= 0) {
-            p.getInventory().removeItem(i);
+            if(p.getInventory().getItemInOffHand().equals(i)) {
+                p.getInventory().setItemInOffHand(null);
+            } else {
+                p.getInventory().removeItem(i);
+            }
             return;
         }
         i.setAmount(i.getAmount() - amount);

--- a/versionsupport_1_16_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_16_R1/v1_16_R1.java
+++ b/versionsupport_1_16_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_16_R1/v1_16_R1.java
@@ -136,7 +136,11 @@ public class v1_16_R1 extends VersionSupport {
     @Override
     public void minusAmount(Player p, org.bukkit.inventory.ItemStack i, int amount) {
         if (i.getAmount() - amount <= 0) {
-            p.getInventory().removeItem(i);
+            if(p.getInventory().getItemInOffHand().equals(i)) {
+                p.getInventory().setItemInOffHand(null);
+            } else {
+                p.getInventory().removeItem(i);
+            }
             return;
         }
         i.setAmount(i.getAmount() - amount);

--- a/versionsupport_1_16_R2/src/main/java/com/andrei1058/bedwars/support/version/v1_16_R2/v1_16_R2.java
+++ b/versionsupport_1_16_R2/src/main/java/com/andrei1058/bedwars/support/version/v1_16_R2/v1_16_R2.java
@@ -136,7 +136,11 @@ public class v1_16_R2 extends VersionSupport {
     @Override
     public void minusAmount(Player p, org.bukkit.inventory.ItemStack i, int amount) {
         if (i.getAmount() - amount <= 0) {
-            p.getInventory().removeItem(i);
+            if(p.getInventory().getItemInOffHand().equals(i)) {
+                p.getInventory().setItemInOffHand(null);
+            } else {
+                p.getInventory().removeItem(i);
+            }
             return;
         }
         i.setAmount(i.getAmount() - amount);

--- a/versionsupport_1_9_R2/src/main/java/com/andrei1058/bedwars/support/version/v1_9_R2/v1_9_R2.java
+++ b/versionsupport_1_9_R2/src/main/java/com/andrei1058/bedwars/support/version/v1_9_R2/v1_9_R2.java
@@ -110,7 +110,11 @@ public class v1_9_R2 extends VersionSupport {
     @Override
     public void minusAmount(Player p, org.bukkit.inventory.ItemStack i, int amount) {
         if (i.getAmount() - amount <= 0) {
-            p.getInventory().removeItem(i);
+            if(p.getInventory().getItemInOffHand().equals(i)) {
+                p.getInventory().setItemInOffHand(null);
+            } else {
+                p.getInventory().removeItem(i);
+            }
             return;
         }
         i.setAmount(i.getAmount() - amount);

--- a/versionsupport_v1_16_R3/src/main/java/com/andrei1058/bedwars/support/version/v1_16_R3/v1_16_R3.java
+++ b/versionsupport_v1_16_R3/src/main/java/com/andrei1058/bedwars/support/version/v1_16_R3/v1_16_R3.java
@@ -136,7 +136,11 @@ public class v1_16_R3 extends VersionSupport {
     @Override
     public void minusAmount(Player p, org.bukkit.inventory.ItemStack i, int amount) {
         if (i.getAmount() - amount <= 0) {
-            p.getInventory().removeItem(i);
+            if(p.getInventory().getItemInOffHand().equals(i)) {
+                p.getInventory().setItemInOffHand(null);
+            } else {
+                p.getInventory().removeItem(i);
+            }
             return;
         }
         i.setAmount(i.getAmount() - amount);

--- a/versionsupport_v1_17_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_17_R1/v1_17_R1.java
+++ b/versionsupport_v1_17_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_17_R1/v1_17_R1.java
@@ -158,7 +158,11 @@ public class v1_17_R1 extends VersionSupport {
     @Override
     public void minusAmount(Player p, org.bukkit.inventory.ItemStack i, int amount) {
         if (i.getAmount() - amount <= 0) {
-            p.getInventory().removeItem(i);
+            if(p.getInventory().getItemInOffHand().equals(i)) {
+                p.getInventory().setItemInOffHand(null);
+            } else {
+                p.getInventory().removeItem(i);
+            }
             return;
         }
         i.setAmount(i.getAmount() - amount);


### PR DESCRIPTION
Fixed "consumables" (fireball, milk, etc) not being removed from the offhand

Turns out `Inventory#removeItem` doesnt remove from the offhand for some reason, so in versions with the offhand (>1.9) you have to check if the item being removed is in the offhand. If so, remove the offhand item.

Fixes #68 