### PR TITLE
fixed #83 HikariCP library issue

### DIFF
--- a/bedwars-plugin/pom.xml
+++ b/bedwars-plugin/pom.xml
@@ -198,7 +198,7 @@
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
-            <version>3.4.5</version>
+            <version>4.0.3</version>
             <optional>true</optional>
             <exclusions>
                 <exclusion>

--- a/bedwars-plugin/pom.xml
+++ b/bedwars-plugin/pom.xml
@@ -198,7 +198,7 @@
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
-            <version>5.0.0</version>
+            <version>3.4.5</version>
             <optional>true</optional>
             <exclusions>
                 <exclusion>
@@ -230,7 +230,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.3</version>
                 <configuration>
                     <relocations>
                         <relocation>


### PR DESCRIPTION
Since HikariCP updated the java version it was getting an unsupported class exception with Java 8, so I just downgraded the version back to `3.4.5`

I accidentally removed the shade version but I don't think it's important 😜