### PR TITLE
Fixed players getting messages for arrows that didnt do damage

### DIFF
--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/DamageDeathMove.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/DamageDeathMove.java
@@ -122,6 +122,7 @@ public class DamageDeathMove implements Listener {
     // show player health on bow hit
     @EventHandler(priority = EventPriority.MONITOR)
     public void onBowHit(EntityDamageByEntityEvent e) {
+        if(e.isCancelled()) return;
         if (e.getEntity().getType() != EntityType.PLAYER) return;
         if (!(e.getDamager() instanceof Projectile)) return;
         Projectile projectile = (Projectile) e.getDamager();


### PR DESCRIPTION
Fixes #89 

Basically, if the damage event was canceled (e.g. a player shooting themselves) they would still get a message. This PR just adds a check: if the event is canceled, dont send the message.