### PR TITLE
Fireball improvements & customizability

### DIFF
--- a/bedwars-api/src/main/java/com/andrei1058/bedwars/api/configuration/ConfigPath.java
+++ b/bedwars-api/src/main/java/com/andrei1058/bedwars/api/configuration/ConfigPath.java
@@ -192,6 +192,10 @@ public class ConfigPath {
     public static final String GENERAL_TNT_JUMP_DAMAGE_TEAMMATES = GENERAL_TNT_JUMP_PATH + ".damage-teammates";
     public static final String GENERAL_TNT_JUMP_DAMAGE_OTHERS = GENERAL_TNT_JUMP_PATH + ".damage-others";
 
+    private static final String GENERAL_FIREBALL_PATH = "fireball";
+    public static final String GENERAL_FIREBALL_DAMAGE_MULTIPLIER = GENERAL_FIREBALL_PATH + ".damage-multiplier";
+    public static final String GENERAL_FIREBALL_EXPLOSION_SIZE = GENERAL_FIREBALL_PATH + ".explosion-size";
+
 
     public static final String GENERAL_CONFIGURATION_PERFORMANCE_PATH = "performance-settings";
     public static final String GENERAL_CONFIGURATION_PERFORMANCE_ROTATE_GEN = GENERAL_CONFIGURATION_PERFORMANCE_PATH + ".rotate-generators";

--- a/bedwars-api/src/main/java/com/andrei1058/bedwars/api/configuration/ConfigPath.java
+++ b/bedwars-api/src/main/java/com/andrei1058/bedwars/api/configuration/ConfigPath.java
@@ -195,6 +195,8 @@ public class ConfigPath {
     private static final String GENERAL_FIREBALL_PATH = "fireball";
     public static final String GENERAL_FIREBALL_DAMAGE_MULTIPLIER = GENERAL_FIREBALL_PATH + ".damage-multiplier";
     public static final String GENERAL_FIREBALL_EXPLOSION_SIZE = GENERAL_FIREBALL_PATH + ".explosion-size";
+    public static final String GENERAL_FIREBALL_SPEED_MULTIPLIER = GENERAL_FIREBALL_PATH + ".speed-multiplier";
+    public static final String GENERAL_FIREBALL_MAKE_FIRE = GENERAL_FIREBALL_PATH + ".make-fire";
 
 
     public static final String GENERAL_CONFIGURATION_PERFORMANCE_PATH = "performance-settings";

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/configuration/MainConfig.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/configuration/MainConfig.java
@@ -100,6 +100,9 @@ public class MainConfig extends ConfigManager {
         yml.addDefault(ConfigPath.GENERAL_TNT_JUMP_DAMAGE_SELF, 1);
         yml.addDefault(ConfigPath.GENERAL_TNT_JUMP_DAMAGE_TEAMMATES, 5);
         yml.addDefault(ConfigPath.GENERAL_TNT_JUMP_DAMAGE_OTHERS, 10);
+        // fireball category
+        yml.addDefault(ConfigPath.GENERAL_FIREBALL_DAMAGE_MULTIPLIER, 0.1);
+        yml.addDefault(ConfigPath.GENERAL_FIREBALL_EXPLOSION_SIZE, 3);
         //
         yml.addDefault("database.enable", false);
         yml.addDefault("database.host", "localhost");

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/configuration/MainConfig.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/configuration/MainConfig.java
@@ -101,7 +101,7 @@ public class MainConfig extends ConfigManager {
         yml.addDefault(ConfigPath.GENERAL_TNT_JUMP_DAMAGE_TEAMMATES, 5);
         yml.addDefault(ConfigPath.GENERAL_TNT_JUMP_DAMAGE_OTHERS, 10);
         // fireball category
-        yml.addDefault(ConfigPath.GENERAL_FIREBALL_DAMAGE_MULTIPLIER, 0.1);
+        yml.addDefault(ConfigPath.GENERAL_FIREBALL_DAMAGE_MULTIPLIER, 0.21);
         yml.addDefault(ConfigPath.GENERAL_FIREBALL_EXPLOSION_SIZE, 3);
         //
         yml.addDefault("database.enable", false);

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/configuration/MainConfig.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/configuration/MainConfig.java
@@ -103,6 +103,8 @@ public class MainConfig extends ConfigManager {
         // fireball category
         yml.addDefault(ConfigPath.GENERAL_FIREBALL_DAMAGE_MULTIPLIER, 0.21);
         yml.addDefault(ConfigPath.GENERAL_FIREBALL_EXPLOSION_SIZE, 3);
+        yml.addDefault(ConfigPath.GENERAL_FIREBALL_SPEED_MULTIPLIER, 10);
+        yml.addDefault(ConfigPath.GENERAL_FIREBALL_MAKE_FIRE, false);
         //
         yml.addDefault("database.enable", false);
         yml.addDefault("database.host", "localhost");

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/DamageDeathMove.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/DamageDeathMove.java
@@ -72,6 +72,7 @@ public class DamageDeathMove implements Listener {
 
     private final double fireballDamageMultiplier;
     private final double fireballExplosionSize;
+    private final boolean fireballMakeFire;
 
     public DamageDeathMove() {
         this.tntJumpBarycenterAlterationInY = config.getYml().getDouble(ConfigPath.GENERAL_TNT_JUMP_BARYCENTER_IN_Y);
@@ -83,6 +84,7 @@ public class DamageDeathMove implements Listener {
 
         this.fireballDamageMultiplier = config.getYml().getDouble(ConfigPath.GENERAL_FIREBALL_DAMAGE_MULTIPLIER);
         this.fireballExplosionSize = config.getYml().getDouble(ConfigPath.GENERAL_FIREBALL_EXPLOSION_SIZE);
+        this.fireballMakeFire = config.getYml().getBoolean(ConfigPath.GENERAL_FIREBALL_MAKE_FIRE);
     }
 
     @EventHandler
@@ -644,6 +646,16 @@ public class DamageDeathMove implements Listener {
     }
 
     @EventHandler
+    public void fireballExplode(ExplosionPrimeEvent e) {
+        if(!(e.getEntity() instanceof Fireball)) return;
+        ProjectileSource shooter = ((Fireball) e.getEntity()).getShooter();
+        if(!(shooter instanceof Player)) return;
+        IArena a = Arena.getArenaByPlayer((Player) shooter);
+        if(a == null) return;
+        e.setCancelled(true);
+    }
+
+    @EventHandler
     public void onProjHit(ProjectileHitEvent e) {
         Projectile proj = e.getEntity();
         if (proj == null) return;
@@ -654,7 +666,7 @@ public class DamageDeathMove implements Listener {
                 if (e.getEntity() instanceof Fireball) {
                     Location l = e.getEntity().getLocation();
                     if (l == null) return;
-                    e.getEntity().getWorld().createExplosion(l.getX(), l.getY(), l.getZ(), (float) fireballExplosionSize, false, true);
+                    e.getEntity().getWorld().createExplosion(l.getX(), l.getY(), l.getZ(), (float) fireballExplosionSize, fireballMakeFire, true);
                     return;
                 }
                 String utility = "";

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/DamageDeathMove.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/DamageDeathMove.java
@@ -70,6 +70,9 @@ public class DamageDeathMove implements Listener {
     private final double tntDamageTeammates;
     private final double tntDamageOthers;
 
+    private final double fireballDamageMultiplier;
+    private final double fireballExplosionSize;
+
     public DamageDeathMove() {
         this.tntJumpBarycenterAlterationInY = config.getYml().getDouble(ConfigPath.GENERAL_TNT_JUMP_BARYCENTER_IN_Y);
         this.tntJumpStrengthReductionConstant = config.getYml().getDouble(ConfigPath.GENERAL_TNT_JUMP_STRENGTH_REDUCTION);
@@ -77,6 +80,9 @@ public class DamageDeathMove implements Listener {
         this.tntDamageSelf = config.getYml().getDouble(ConfigPath.GENERAL_TNT_JUMP_DAMAGE_SELF);
         this.tntDamageTeammates = config.getYml().getDouble(ConfigPath.GENERAL_TNT_JUMP_DAMAGE_TEAMMATES);
         this.tntDamageOthers = config.getYml().getDouble(ConfigPath.GENERAL_TNT_JUMP_DAMAGE_OTHERS);
+
+        this.fireballDamageMultiplier = config.getYml().getDouble(ConfigPath.GENERAL_FIREBALL_DAMAGE_MULTIPLIER);
+        this.fireballExplosionSize = config.getYml().getDouble(ConfigPath.GENERAL_FIREBALL_EXPLOSION_SIZE);
     }
 
     @EventHandler
@@ -110,6 +116,11 @@ public class DamageDeathMove implements Listener {
                     } else BedWarsTeam.reSpawnInvulnerability.remove(p.getUniqueId());
                 }
                 //}
+
+                // Fireball is BLOCK_EXPLOSION because of spawned explosion
+                if(e.getCause() == EntityDamageEvent.DamageCause.BLOCK_EXPLOSION) {
+                    e.setDamage(e.getDamage()*fireballDamageMultiplier);
+                }
             }
         }
         if (BedWars.getServerType() == ServerType.MULTIARENA) {
@@ -643,7 +654,7 @@ public class DamageDeathMove implements Listener {
                 if (e.getEntity() instanceof Fireball) {
                     Location l = e.getEntity().getLocation();
                     if (l == null) return;
-                    e.getEntity().getWorld().createExplosion(l.getX(), l.getY(), l.getZ(), 3, false, true);
+                    e.getEntity().getWorld().createExplosion(l.getX(), l.getY(), l.getZ(), (float) fireballExplosionSize, false, true);
                     return;
                 }
                 String utility = "";

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/Interact.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/Interact.java
@@ -57,6 +57,12 @@ import static com.andrei1058.bedwars.api.language.Language.getMsg;
 
 public class Interact implements Listener {
 
+    private final double fireballSpeedMultiplier;
+
+    public Interact() {
+        this.fireballSpeedMultiplier = config.getYml().getDouble(ConfigPath.GENERAL_FIREBALL_SPEED_MULTIPLIER);
+    }
+
     @EventHandler
     /* Handle custom items with commands on them */
     public void onItemCommand(PlayerInteractEvent e) {
@@ -193,7 +199,7 @@ public class Interact implements Listener {
                         Fireball fb = p.launchProjectile(Fireball.class);
                         Vector direction = p.getEyeLocation().getDirection();
                         fb = nms.setFireballDirection(fb, direction);
-                        fb.setVelocity(fb.getDirection().multiply(2));
+                        fb.setVelocity(fb.getDirection().multiply(fireballSpeedMultiplier));
                         fb.setIsIncendiary(false);
                         fb.setMetadata("bw1058", new FixedMetadataValue(plugin, "ceva"));
                         nms.minusAmount(p, inHand, 1);


### PR DESCRIPTION
This PR has several improvements to fireballs

* Reduced fireball damage with a multiplier (customizable in the config)
* Removed double explosion noise (canceled vanilla fireball explosion)
* Made fireball explosion size customizable (not sure why, but why not)
* Made fireball speed configurable (and set the default to be similar to big h, according to kimo)
* Added config option to make fireball make fire (which big h does according to kimo) Defaults to false to make sure updating doesnt suddenly cause a bunch of players maps to burn down because they dont have firetick set

A new "fireball" section in the config was made for all of these customizations

HUGE thanks to kimo for helping me test this.