### PR TITLE
Different bed break sound for the victim team

### DIFF
--- a/bedwars-api/src/main/java/com/andrei1058/bedwars/api/configuration/ConfigPath.java
+++ b/bedwars-api/src/main/java/com/andrei1058/bedwars/api/configuration/ConfigPath.java
@@ -167,6 +167,7 @@ public class ConfigPath {
     public static final String SOUNDS_COUNTDOWN_TICK_X = "game-countdown-s";
     public static final String SOUND_GAME_START = "game-countdown-start";
     public static final String SOUNDS_BED_DESTROY = "bed-destroy";
+    public static final String SOUNDS_BED_DESTROY_OWN = "bed-destroy-own";
     public static final String SOUNDS_INSUFF_MONEY = "shop-insufficient-money";
     public static final String SOUNDS_BOUGHT = "shop-bought";
 

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/configuration/Sounds.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/configuration/Sounds.java
@@ -63,6 +63,7 @@ public class Sounds {
         addDefSound(SOUND_GAME_START, BedWars.getForCurrentVersion("SLIME_ATTACK", "BLOCK_SLIME_FALL", "BLOCK_SLIME_BLOCK_FALL"));
 
         addDefSound(SOUNDS_BED_DESTROY, BedWars.getForCurrentVersion("ENDERDRAGON_GROWL", "ENTITY_ENDERDRAGON_GROWL", "ENTITY_ENDER_DRAGON_GROWL"));
+        addDefSound(SOUNDS_BED_DESTROY_OWN, BedWars.getForCurrentVersion("WITHER_DEATH", "ENTITY_WITHER_DEATH", "ENTITY_WITHER_DEATH"));
         addDefSound(SOUNDS_INSUFF_MONEY, BedWars.getForCurrentVersion("VILLAGER_NO", "ENTITY_VILLAGER_NO", "ENTITY_VILLAGER_NO"));
         addDefSound(SOUNDS_BOUGHT, BedWars.getForCurrentVersion("VILLAGER_YES", "ENTITY_VILLAGER_YES", "ENTITY_VILLAGER_YES"));
 

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/BreakPlace.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/BreakPlace.java
@@ -309,7 +309,8 @@ public class BreakPlace implements Listener {
                                                 if (breakEvent.getTitle() != null && breakEvent.getSubTitle() != null) {
                                                     nms.sendTitle(on, breakEvent.getTitle().apply(on), breakEvent.getSubTitle().apply(on), 0, 25, 0);
                                                 }
-                                                Sounds.playSound(ConfigPath.SOUNDS_BED_DESTROY, on);
+                                                if (t.isMember(on)) Sounds.playSound(ConfigPath.SOUNDS_BED_DESTROY_OWN, on);
+                                                else Sounds.playSound(ConfigPath.SOUNDS_BED_DESTROY, on);
                                             }
                                         }
                                         return;


### PR DESCRIPTION
This small PR adds a new sound to the sound.yml configuration: "**bed-destroy-own**".

The victim team will hear this sound when their bed breaks, and the rest of the players will hear the regular "bed-destroy" sound. This feature is useful on servers like Hypixel to know when your bed breaks easily.