### PR TITLE
Add a note about merged issues in the bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,6 +7,10 @@ assignees: ''
 
 ---
 
+<!-- 
+NOTE: Please do not merge multiple bugs into one issue.
+It is easier to address the bugs if they are created as seperate issues
+-->
 **Describe the bug**
 A clear and concise description of what the bug is.
 


### PR DESCRIPTION
I've seen several issues with more than one bug in them that have nothing to do with each other. This makes it harder to address the issues separately. This will hopefully prevent people from doing that.