### PR TITLE
Spectator break fix

### DIFF
--- a/bedwars-api/src/main/java/com/andrei1058/bedwars/api/arena/IArena.java
+++ b/bedwars-api/src/main/java/com/andrei1058/bedwars/api/arena/IArena.java
@@ -485,4 +485,6 @@ public interface IArena {
     ITeamAssigner getTeamAssigner();
 
     void setTeamAssigner(ITeamAssigner teamAssigner);
+
+    List<Player> getLeavingPlayers();
 }

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/Arena.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/Arena.java
@@ -618,8 +618,6 @@ public class Arena implements IArena {
                 reJoin.destroy(true);
             }
 
-            leaving.remove(p);
-
             p.closeInventory();
             spectators.add(p);
             players.remove(p);
@@ -649,6 +647,7 @@ public class Arena implements IArena {
             p.setGameMode(GameMode.ADVENTURE);
 
             Bukkit.getScheduler().runTaskLater(plugin, () -> {
+                if(leaving.contains(p)) return;
                 p.setAllowFlight(true);
                 p.setFlying(true);
             }, 5L);
@@ -657,6 +656,7 @@ public class Arena implements IArena {
                 p.getPassenger().remove();
 
             Bukkit.getScheduler().runTask(plugin, () -> {
+                if(leaving.contains(p)) return;
                 for (Player on : Bukkit.getOnlinePlayers()) {
                     if (on == p) continue;
                     if (getSpectators().contains(on)) {
@@ -692,6 +692,8 @@ public class Arena implements IArena {
 
                 p.getInventory().setArmorContents(null);
             });
+
+            leaving.remove(p);
 
             p.sendMessage(getMsg(p, Messages.COMMAND_JOIN_SPECTATOR_MSG).replace("{arena}", this.getDisplayName()));
 
@@ -987,6 +989,13 @@ public class Arena implements IArena {
      */
     public void removeSpectator(@NotNull Player p, boolean disconnect) {
         debug("Spectator removed: " + p.getName() + " arena: " + getArenaName());
+
+        if(leaving.contains(p)) {
+            return;
+        } else {
+            leaving.add(p);
+        }
+
         Bukkit.getPluginManager().callEvent(new PlayerLeaveArenaEvent(p, this, null));
         spectators.remove(p);
         removeArenaByPlayer(p, this);

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/Arena.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/Arena.java
@@ -650,7 +650,7 @@ public class Arena implements IArena {
             if (p.getPassenger() != null && p.getPassenger().getType() == EntityType.ARMOR_STAND)
                 p.getPassenger().remove();
 
-            Bukkit.getScheduler().runTaskLater(plugin, () -> {
+            Bukkit.getScheduler().runTask(plugin, () -> {
                 for (Player on : Bukkit.getOnlinePlayers()) {
                     if (on == p) continue;
                     if (getSpectators().contains(on)) {
@@ -685,7 +685,7 @@ public class Arena implements IArena {
                 p.addPotionEffect(new PotionEffect(PotionEffectType.INVISIBILITY, Integer.MAX_VALUE, 1, false));
 
                 p.getInventory().setArmorContents(null);
-            }, 25L);
+            });
 
             p.sendMessage(getMsg(p, Messages.COMMAND_JOIN_SPECTATOR_MSG).replace("{arena}", this.getDisplayName()));
 
@@ -1017,7 +1017,7 @@ public class Arena implements IArena {
         }
         playerLocation.remove(p);
 
-        Bukkit.getScheduler().runTaskLater(plugin, () -> {
+        Bukkit.getScheduler().runTask(plugin, () -> {
             for (Player on : Bukkit.getOnlinePlayers()) {
                 if (on.equals(p)) continue;
                 if (getArenaByPlayer(on) == null) {
@@ -1029,7 +1029,7 @@ public class Arena implements IArena {
                 }
             }
             if (!disconnect) BedWarsScoreboard.giveScoreboard(p, null, true);
-        }, 10L);
+        });
 
         /* Remove also the party */
         if (getParty().hasParty(p)) {

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/Arena.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/Arena.java
@@ -124,6 +124,8 @@ public class Arena implements IArena {
     private List<Region> regionsList = new ArrayList<>();
     private int renderDistance;
 
+    private final List<Player> leaving = new ArrayList<>();
+
     /**
      * Current event, used at scoreboard
      */
@@ -454,6 +456,8 @@ public class Arena implements IArena {
             }
         }
 
+        leaving.remove(p);
+
         if (status == GameState.waiting || (status == GameState.starting && (startingTask != null && startingTask.getCountdown() > 1))) {
             if (players.size() >= maxPlayers && !isVip(p)) {
                 TextComponent text = new TextComponent(getMsg(p, Messages.COMMAND_JOIN_DENIED_IS_FULL));
@@ -614,6 +618,8 @@ public class Arena implements IArena {
                 reJoin.destroy(true);
             }
 
+            leaving.remove(p);
+
             p.closeInventory();
             spectators.add(p);
             players.remove(p);
@@ -723,6 +729,11 @@ public class Arena implements IArena {
      * @param disconnect True if the player was disconnected
      */
     public void removePlayer(@NotNull Player p, boolean disconnect) {
+        if(leaving.contains(p)) {
+            return;
+        } else {
+            leaving.add(p);
+        }
         debug("Player removed: " + p.getName() + " arena: " + getArenaName());
         respawnSessions.remove(p);
 
@@ -2360,6 +2371,7 @@ public class Arena implements IArena {
         oreGenerators = null;
         perMinuteTask = null;
         moneyperMinuteTask = null;
+        leaving.clear();
     }
 
     /**
@@ -2560,6 +2572,11 @@ public class Arena implements IArena {
             this.teamAssigner = teamAssigner;
             plugin.getLogger().warning("Using " + teamAssigner.getClass().getSimpleName() + " team assigner on arena: " + this.getArenaName());
         }
+    }
+
+    @Override
+    public List<Player> getLeavingPlayers() {
+        return leaving;
     }
 
     /**

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/QuitAndTeleportListener.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/QuitAndTeleportListener.java
@@ -139,8 +139,8 @@ public class QuitAndTeleportListener implements Listener {
                 //}, 2L);
             }
         }
-        if (Arena.isInArena(e.getPlayer())) {
-            IArena a = Arena.getArenaByPlayer(e.getPlayer());
+        IArena a = Arena.getArenaByPlayer(e.getPlayer());
+        if (a != null) {
             if (a.isPlayer(e.getPlayer())) {
                 if (a.getStatus() == GameState.waiting || a.getStatus() == GameState.starting) return;
                 if (!e.getPlayer().getWorld().getName().equalsIgnoreCase(a.getWorld().getName())) {


### PR DESCRIPTION
Fixes spectators being able to join, leave quickly, then rejoin and be able to break blocks.

Fixes #111

Depends on #110 