### PR TITLE
Player gamemode change on re-join

### DIFF
--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/ReJoin.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/ReJoin.java
@@ -32,6 +32,8 @@ import com.andrei1058.bedwars.configuration.Sounds;
 import com.andrei1058.bedwars.lobbysocket.ArenaSocket;
 import com.andrei1058.bedwars.shop.ShopCache;
 import com.google.gson.JsonObject;
+import org.bukkit.Bukkit;
+import org.bukkit.GameMode;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -141,8 +143,17 @@ public class ReJoin {
      * Make a player re-join the arena
      */
     public boolean reJoin(Player player) {
+
         Sounds.playSound("rejoin-allowed", player);
         player.sendMessage(Language.getMsg(player, Messages.REJOIN_ALLOWED).replace("{arena}", getArena().getDisplayName()));
+
+        if (player.getGameMode() != GameMode.SURVIVAL) {
+            Bukkit.getScheduler().runTaskLater(BedWars.plugin, () -> {
+                player.setGameMode(GameMode.SURVIVAL);
+                player.setAllowFlight(true);
+                player.setFlying(true);
+            }, 20L);
+        }
         return arena.reJoin(player);
     }
 

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/tasks/GamePlayingTask.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/tasks/GamePlayingTask.java
@@ -224,6 +224,8 @@ public class GamePlayingTask implements Runnable, PlayingTask {
                         a.addSpectator(e.getKey(), true, null);
                     } else {
                         t.respawnMember(e.getKey());
+                        e.getKey().setAllowFlight(false);
+                        e.getKey().setFlying(false);
                     }
                 } else {
                     nms.sendTitle(e.getKey(), getMsg(e.getKey(), Messages.PLAYER_DIE_RESPAWN_TITLE).replace("{time}",


### PR DESCRIPTION
Sets the player to gamemode survival upon re-join to the game
When the player re-joined the gamemode was set to the one he had in the lobby

Fixes #55
Fixes #145