### PR TITLE
Allows the Bow Hit message to be disabled (FIXED)

### DIFF
--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/DamageDeathMove.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/DamageDeathMove.java
@@ -38,6 +38,7 @@ import com.andrei1058.bedwars.arena.LastHit;
 import com.andrei1058.bedwars.arena.SetupSession;
 import com.andrei1058.bedwars.arena.team.BedWarsTeam;
 import com.andrei1058.bedwars.listeners.dropshandler.PlayerDrops;
+import org.apache.commons.lang.StringUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
@@ -151,6 +152,7 @@ public class DamageDeathMove implements Listener {
         // projectile hit message #696, #711
         ITeam team = a.getTeam(p);
         Language lang = Language.getPlayerLanguage(damager);
+        if (StringUtils.isEmpty(lang.m(Messages.PLAYER_HIT_BOW))) return;
         String message = lang.m(Messages.PLAYER_HIT_BOW)
                 .replace("{amount}", new DecimalFormat("00.#").format(((Player) e.getEntity()).getHealth() - e.getFinalDamage()))
                 .replace("{TeamColor}", team.getColor().chat().toString())

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/DamageDeathMove.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/DamageDeathMove.java
@@ -151,7 +151,7 @@ public class DamageDeathMove implements Listener {
         // projectile hit message #696, #711
         ITeam team = a.getTeam(p);
         Language lang = Language.getPlayerLanguage(damager);
-        if (lang.m(Messages.PLAYER_HIT_BOW).length() == 0) return;
+        if (lang.m(Messages.PLAYER_HIT_BOW).isEmpty()) return;
         String message = lang.m(Messages.PLAYER_HIT_BOW)
                 .replace("{amount}", new DecimalFormat("00.#").format(((Player) e.getEntity()).getHealth() - e.getFinalDamage()))
                 .replace("{TeamColor}", team.getColor().chat().toString())

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/DamageDeathMove.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/DamageDeathMove.java
@@ -38,7 +38,6 @@ import com.andrei1058.bedwars.arena.LastHit;
 import com.andrei1058.bedwars.arena.SetupSession;
 import com.andrei1058.bedwars.arena.team.BedWarsTeam;
 import com.andrei1058.bedwars.listeners.dropshandler.PlayerDrops;
-import org.apache.commons.lang.StringUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
@@ -152,7 +151,7 @@ public class DamageDeathMove implements Listener {
         // projectile hit message #696, #711
         ITeam team = a.getTeam(p);
         Language lang = Language.getPlayerLanguage(damager);
-        if (StringUtils.isEmpty(lang.m(Messages.PLAYER_HIT_BOW))) return;
+        if (lang.m(Messages.PLAYER_HIT_BOW).length() == 0) return;
         String message = lang.m(Messages.PLAYER_HIT_BOW)
                 .replace("{amount}", new DecimalFormat("00.#").format(((Player) e.getEntity()).getHealth() - e.getFinalDamage()))
                 .replace("{TeamColor}", team.getColor().chat().toString())


### PR DESCRIPTION
added the ability to set Messages.PLAYER_HIT_BOW to empty to disable the message