### PR TITLE
fix PlayerBedBreakEvent message

### DIFF
--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/BreakPlace.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/BreakPlace.java
@@ -281,13 +281,9 @@ public class BreakPlace implements Listener {
                                             Bukkit.getPluginManager().callEvent(breakEvent = new PlayerBedBreakEvent(e.getPlayer(), a.getTeam(p), t, a,
                                                     player -> {
                                                         if (t.isMember(player)) {
-                                                            return getMsg(player, Messages.INTERACT_BED_DESTROY_CHAT_ANNOUNCEMENT_TO_VICTIM).replace("{TeamColor}",
-                                                                            t.getColor().chat().toString()).replace("{TeamName}", t.getDisplayName(Language.getPlayerLanguage(player)))
-                                                                    .replace("{PlayerColor}", a.getTeam(p).getColor().chat().toString()).replace("{PlayerName}", p.getDisplayName());
+                                                            return getMsg(player, Messages.INTERACT_BED_DESTROY_CHAT_ANNOUNCEMENT_TO_VICTIM);
                                                         } else {
-                                                            return getMsg(player, Messages.INTERACT_BED_DESTROY_CHAT_ANNOUNCEMENT).replace("{TeamColor}",
-                                                                            t.getColor().chat().toString()).replace("{TeamName}", t.getDisplayName(Language.getPlayerLanguage(player)))
-                                                                    .replace("{PlayerColor}", a.getTeam(p).getColor().chat().toString()).replace("{PlayerName}", p.getDisplayName());
+                                                            return getMsg(player, Messages.INTERACT_BED_DESTROY_CHAT_ANNOUNCEMENT);
                                                         }
                                                     },
                                                     player -> {
@@ -304,7 +300,11 @@ public class BreakPlace implements Listener {
                                                     }));
                                             for (Player on : a.getWorld().getPlayers()) {
                                                 if (breakEvent.getMessage() != null) {
-                                                    on.sendMessage(breakEvent.getMessage().apply(on));
+                                                    on.sendMessage(breakEvent.getMessage().apply(on)
+                                                            .replace("{TeamColor}", t.getColor().chat().toString())
+                                                            .replace("{TeamName}", t.getDisplayName(Language.getPlayerLanguage(on)))
+                                                            .replace("{PlayerColor}", a.getTeam(p).getColor().chat().toString())
+                                                            .replace("{PlayerName}", p.getDisplayName()));
                                                 }
                                                 if (breakEvent.getTitle() != null && breakEvent.getSubTitle() != null) {
                                                     nms.sendTitle(on, breakEvent.getTitle().apply(on), breakEvent.getSubTitle().apply(on), 0, 25, 0);


### PR DESCRIPTION
### Identify the Bug
If you use method **setMessage()** of class **PlayerBedBreakEvent**, placeholders will not work.
This is because those placeholders are being replaced before the event is passed to other plugins.
### Description of the Change
Replace bed break message placeholders after the event is called, this way placeholders will work even if the message is changed by another plugin using this event.
### Alternate Designs
Other plugins using this event can technically replace those placeholders themselves.
But this design is better because you have to replace those placeholders anyway _(and PlayerKillEvent does the same too)_