### PR TITLE
Dont disable generators until all team members are dead

### DIFF
--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/team/BedWarsTeam.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/team/BedWarsTeam.java
@@ -732,12 +732,6 @@ public class BedWarsTeam implements ITeam {
             nms.colorBed(this);
         } else {
             bed.getBlock().setType(Material.AIR);
-            if (getArena().getConfig().getBoolean(ConfigPath.ARENA_DISABLE_GENERATOR_FOR_EMPTY_TEAMS)) {
-                for (IGenerator g : getGenerators()) {
-                    g.disable();
-                }
-                generators.clear();
-            }
         }
         for (BedHolo bh : beds.values()) {
             bh.hide();

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/DamageDeathMove.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/DamageDeathMove.java
@@ -483,6 +483,14 @@ public class DamageDeathMove implements Listener {
             if (lastHit != null) {
                 lastHit.setDamager(null);
             }
+
+
+            if (victimsTeam.isBedDestroyed() && victimsTeam.getSize() == 1 &&  a.getConfig().getBoolean(ConfigPath.ARENA_DISABLE_GENERATOR_FOR_EMPTY_TEAMS)) {
+                for (IGenerator g : victimsTeam.getGenerators()) {
+                    g.disable();
+                }
+                victimsTeam.getGenerators().clear();
+            }
         }
     }
 


### PR DESCRIPTION
Instead of disabling the generator when the team's bed is broken, now only disable it once the last player on that team dies.

Fixes #133 