### PR TITLE
Use https in placeholderapi repo

### DIFF
--- a/bedwars-plugin/pom.xml
+++ b/bedwars-plugin/pom.xml
@@ -19,7 +19,7 @@
         </repository>
         <repository>
             <id>placeholderapi</id>
-            <url>http://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+            <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
         </repository>
         <repository>
             <id>spigotutils-maven</id>


### PR DESCRIPTION
Newer versions of maven completly freak out if any repos use http instead of https