### PR TITLE
Make arena accessible from shop events

### DIFF
--- a/bedwars-api/src/main/java/com/andrei1058/bedwars/api/events/shop/ShopBuyEvent.java
+++ b/bedwars-api/src/main/java/com/andrei1058/bedwars/api/events/shop/ShopBuyEvent.java
@@ -20,6 +20,7 @@
 
 package com.andrei1058.bedwars.api.events.shop;
 
+import com.andrei1058.bedwars.api.arena.IArena;
 import com.andrei1058.bedwars.api.arena.shop.ICategoryContent;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
@@ -31,15 +32,33 @@ public class ShopBuyEvent extends Event implements Cancellable {
     private static final HandlerList HANDLERS = new HandlerList();
 
     private final Player buyer;
+    private final IArena arena;
     private final ICategoryContent categoryContent;
     private boolean cancelled = false;
 
     /**
      * Triggered when a player buys from the shop
+     * 
+     * @deprecated Use {@link #ShopBuyEvent(Player, IArena, ICategoryContent)}
      */
+    @Deprecated
     public ShopBuyEvent(Player buyer, ICategoryContent categoryContent) {
         this.categoryContent = categoryContent;
         this.buyer = buyer;
+        this.arena = null;
+    }
+
+    /**
+     * Triggered when a player buys from the shop
+     */
+    public ShopBuyEvent(Player buyer, IArena arena, ICategoryContent categoryContent) {
+        this.categoryContent = categoryContent;
+        this.buyer = buyer;
+        this.arena = arena;
+    }
+
+    public IArena getArena() {
+        return arena;
     }
 
     /**

--- a/bedwars-api/src/main/java/com/andrei1058/bedwars/api/events/shop/ShopOpenEvent.java
+++ b/bedwars-api/src/main/java/com/andrei1058/bedwars/api/events/shop/ShopOpenEvent.java
@@ -20,6 +20,7 @@
 
 package com.andrei1058.bedwars.api.events.shop;
 
+import com.andrei1058.bedwars.api.arena.IArena;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
@@ -29,13 +30,30 @@ public class ShopOpenEvent extends Event {
     private static final HandlerList HANDLERS = new HandlerList();
 
     private Player player;
+    private final IArena arena;
     private boolean cancelled = false;
 
     /**
      * Triggered when the shop NPS is clicked.
+     * 
+     * @deprecated Use {@link #ShopOpenEvent(Player, IArena)}
      */
+    @Deprecated
     public ShopOpenEvent(Player player) {
         this.player = player;
+        this.arena = null;
+    }
+
+    /**
+     * Triggered when the shop NPS is clicked.
+     */
+    public ShopOpenEvent(Player player, IArena arena) {
+        this.player = player;
+        this.arena = arena;
+    }
+
+    public IArena getArena() {
+        return arena;
     }
 
     /**

--- a/bedwars-api/src/main/java/com/andrei1058/bedwars/api/events/upgrades/UpgradeBuyEvent.java
+++ b/bedwars-api/src/main/java/com/andrei1058/bedwars/api/events/upgrades/UpgradeBuyEvent.java
@@ -20,6 +20,7 @@
 
 package com.andrei1058.bedwars.api.events.upgrades;
 
+import com.andrei1058.bedwars.api.arena.IArena;
 import com.andrei1058.bedwars.api.arena.team.ITeam;
 import com.andrei1058.bedwars.api.upgrades.TeamUpgrade;
 import org.bukkit.entity.Player;
@@ -31,6 +32,7 @@ public class UpgradeBuyEvent extends Event {
 
     private TeamUpgrade teamUpgrade;
     private Player player;
+    private final IArena arena;
     private ITeam team;
 
     /**
@@ -40,6 +42,11 @@ public class UpgradeBuyEvent extends Event {
         this.teamUpgrade = teamUpgrade;
         this.player = player;
         this.team = team;
+        this.arena = team.getArena();
+    }
+
+    public IArena getArena() {
+        return arena;
     }
 
     /**

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/shop/main/CategoryContent.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/shop/main/CategoryContent.java
@@ -171,7 +171,7 @@ public class CategoryContent implements ICategoryContent {
 
         ShopBuyEvent event;
         //call shop buy event
-        Bukkit.getPluginManager().callEvent(event = new ShopBuyEvent(player, this));
+        Bukkit.getPluginManager().callEvent(event = new ShopBuyEvent(player, Arena.getArenaByPlayer(player), this));
 
         if (event.isCancelled()){
             return;

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/shop/main/ShopIndex.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/shop/main/ShopIndex.java
@@ -23,6 +23,7 @@ package com.andrei1058.bedwars.shop.main;
 import com.andrei1058.bedwars.BedWars;
 import com.andrei1058.bedwars.api.events.shop.ShopOpenEvent;
 import com.andrei1058.bedwars.api.language.Language;
+import com.andrei1058.bedwars.arena.Arena;
 import com.andrei1058.bedwars.shop.ShopCache;
 import com.andrei1058.bedwars.shop.quickbuy.PlayerQuickBuyCache;
 import org.bukkit.Bukkit;
@@ -78,7 +79,7 @@ public class ShopIndex {
         if (quickBuyCache == null) return;
 
         if (callEvent) {
-            ShopOpenEvent event = new ShopOpenEvent(player);
+            ShopOpenEvent event = new ShopOpenEvent(player, Arena.getArenaByPlayer(player));
             Bukkit.getPluginManager().callEvent(event);
             if (event.isCancelled()) return;
         }


### PR DESCRIPTION
### Issue

N/A

### Description of the Change

Provides a getter for the current Arena object, like most other events already do.

### Alternate Designs

N/A

### Possible Drawbacks

None, I've kept the original constructors to maintain backwards compatibility.

### Verification Process

Tested on live server.

### Release Notes

Made arena accessible from shop events