### PR TITLE
fix player skull crashing the server

### DIFF
--- a/versionsupport_v1_17_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_17_R1/v1_17_R1.java
+++ b/versionsupport_v1_17_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_17_R1/v1_17_R1.java
@@ -546,15 +546,19 @@ public class v1_17_R1 extends VersionSupport {
         }
 
         SkullMeta headMeta = (SkullMeta) head.getItemMeta();
-        Field profileField;
-        try {
-            //noinspection ConstantConditions
-            profileField = headMeta.getClass().getDeclaredField("profile");
-            profileField.setAccessible(true);
-            profileField.set(headMeta, ((CraftPlayer) player).getProfile());
-        } catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException e1) {
-            e1.printStackTrace();
-        }
+//        FIXME: current hotfix will get rate limited! how the hell do we set head texture now?
+//        wtf is this: SkullOwner:{Id:[I;-1344581477,-1919271229,-1306015584,-647763423],Name:"andrei1058"}
+//        Field profileField;
+//        try {
+//            //noinspection ConstantConditions
+//            profileField = headMeta.getClass().getDeclaredField("profile");
+//            profileField.setAccessible(true);
+//            profileField.set(headMeta, ((CraftPlayer) player).getProfile());
+//        } catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException e1) {
+//            e1.printStackTrace();
+//        }
+        assert headMeta != null;
+        headMeta.setOwningPlayer(player);
         head.setItemMeta(headMeta);
 
         return head;

--- a/versionsupport_v1_18_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_18_R1/v1_18_R1.java
+++ b/versionsupport_v1_18_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_18_R1/v1_18_R1.java
@@ -545,7 +545,7 @@ public class v1_18_R1 extends VersionSupport {
             head = CraftItemStack.asBukkitCopy(i);
         }
 
-        SkullMeta headMeta = (SkullMeta) head.getItemMeta();
+//        SkullMeta headMeta = (SkullMeta) head.getItemMeta();
 //        FIXME: current hotfix will get rate limited! how the hell do we set head texture now?
 //        wtf is this: SkullOwner:{Id:[I;-1344581477,-1919271229,-1306015584,-647763423],Name:"andrei1058"}
 //        Field profileField;
@@ -557,9 +557,9 @@ public class v1_18_R1 extends VersionSupport {
 //        } catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException e1) {
 //            e1.printStackTrace();
 //        }
-        assert headMeta != null;
-        headMeta.setOwningPlayer(player);
-        head.setItemMeta(headMeta);
+//        assert headMeta != null;
+//        headMeta.setOwningPlayer(player);
+//        head.setItemMeta(headMeta);
 
         return head;
     }

--- a/versionsupport_v1_18_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_18_R1/v1_18_R1.java
+++ b/versionsupport_v1_18_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_18_R1/v1_18_R1.java
@@ -160,7 +160,7 @@ public class v1_18_R1 extends VersionSupport {
     @Override
     public void minusAmount(Player p, org.bukkit.inventory.ItemStack i, int amount) {
         if (i.getAmount() - amount <= 0) {
-            if(p.getInventory().getItemInOffHand().equals(i)) {
+            if (p.getInventory().getItemInOffHand().equals(i)) {
                 p.getInventory().setItemInOffHand(null);
             } else {
                 p.getInventory().removeItem(i);
@@ -546,15 +546,19 @@ public class v1_18_R1 extends VersionSupport {
         }
 
         SkullMeta headMeta = (SkullMeta) head.getItemMeta();
-        Field profileField;
-        try {
-            //noinspection ConstantConditions
-            profileField = headMeta.getClass().getDeclaredField("profile");
-            profileField.setAccessible(true);
-            profileField.set(headMeta, ((CraftPlayer) player).getProfile());
-        } catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException e1) {
-            e1.printStackTrace();
-        }
+//        FIXME: current hotfix will get rate limited! how the hell do we set head texture now?
+//        wtf is this: SkullOwner:{Id:[I;-1344581477,-1919271229,-1306015584,-647763423],Name:"andrei1058"}
+//        Field profileField;
+//        try {
+//            //noinspection ConstantConditions
+//            profileField = headMeta.getClass().getDeclaredField("profile");
+//            profileField.setAccessible(true);
+//            profileField.set(headMeta, ((CraftPlayer) player).getProfile());
+//        } catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException e1) {
+//            e1.printStackTrace();
+//        }
+        assert headMeta != null;
+        headMeta.setOwningPlayer(player);
         head.setItemMeta(headMeta);
 
         return head;
@@ -695,6 +699,6 @@ public class v1_18_R1 extends VersionSupport {
 
     @Override
     public void clearArrowsFromPlayerBody(Player player) {
-        ((CraftLivingEntity)player).getHandle().ai().a(new DataWatcherObject<>(12, DataWatcherRegistry.b),-1);
+        ((CraftLivingEntity) player).getHandle().ai().a(new DataWatcherObject<>(12, DataWatcherRegistry.b), -1);
     }
 }


### PR DESCRIPTION
fix #210 
fix #223

I tried to inject the texture but it looks like they changed the structure. There's no texture key on skulls now. This is a working texture made with #setOwningPlayer: 
`SkullOwner:{Id:[I;-1344581477,-1919271229,-1306015584,-647763423],Name:"andrei1058"}`

I have no idea what the ID is nor how to get a cached one.

EDIT: now I got this :|||
```json
SkullOwner:{Id:[I;-1732928944,2068205531,-1895484687,-2069866675],Name:"andrei1058",Properties:{textures:[{Signature:"Ox8Qy4X2sZAYW0AB8R7cRuNYsxJqUzG7zXwdVTGb9CDvyXnK7aNRR8NwFGgVEwWko5JuXQ+zai7C0EsfwOpfm+8B2x0umcKHMqwgZr5f875AqeDEm3/2idkj6tVTYIAq4CwGh8171OQf3EtT0W7vC1sFcYR3CO5wpt5cEw3XiZQs0j9NXgRHed1ZpF58prN0z0AFcworkalZeZVk2wgXA3FUrJlZAZD/uR6vbj75TOCz32NXywGrRnvb1KaaAbtrNRKVDba8TT1lo1OCL/osJd6idvTu+rDX2N40l7uh6JqObhAqkeArcNN2cu8vFuo+49WxlJoxzmQ5+WXyc4sAy0SQTa3W8dJMO41ejI0RqD+4BNOlH7//vKDYxynfSE+mcd5QMOEwBrShoAL9arsREgmCK8f1VzvbEHz8LAT4itLB1m+vcjIDPuID1uDY/rNcU1hpwP4N8P4PA6xwkXhbhMn3Q7o9qV2ILeVxPZc8W49uDKjcWX+UURyJ7UEOsuiz8QDGSk1P7VfemgHPQp+MVtj4t2fkpMSgiW8Dl+8kRyDXBhHW7MkwXImt8b3xQcd/6RJudwmiw6qOIPiGjdixZG2a1hdK/ko9vWBWLOpXkpEO7DSAws884d8iFg/R56t5S2prwe8OCow+vcWVL5cXTUOu330lRrzc4whoLqQIdCk=",Value:"ewogICJ0aW1lc3RhbXAiIDogMTY0MDUyMTQ5NDcwOSwKICAicHJvZmlsZUlkIiA6ICI5OGI1OWE1MDdiNDY0ZmRiOGYwNTMyZjE4NGEwNTc0ZCIsCiAgInByb2ZpbGVOYW1lIiA6ICJhbmRyZWkxMDU4IiwKICAic2lnbmF0dXJlUmVxdWlyZWQiIDogdHJ1ZSwKICAidGV4dHVyZXMiIDogewogICAgIlNLSU4iIDogewogICAgICAidXJsIiA6ICJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzFmMjcyMDYwZjdhZGY3OWMzYzIzZjI4Y2JmYWJlZGRmNmNlYjQ4MzUxZjI1ZWFiOTI2YTE0NTI5NWU3YzAyMGQiCiAgICB9LAogICAgIkNBUEUiIDogewogICAgICAidXJsIiA6ICJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzIzNDBjMGUwM2RkMjRhMTFiMTVhOGIzM2MyYTdlOWUzMmFiYjIwNTFiMjQ4MWQwYmE3ZGVmZDYzNWNhN2E5MzMiCiAgICB9CiAgfQp9"}]}}
```