### PR TITLE
Improved arena group command

### DIFF
--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/commands/bedwars/subcmds/sensitive/ArenaGroup.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/commands/bedwars/subcmds/sensitive/ArenaGroup.java
@@ -151,13 +151,9 @@ public class ArenaGroup extends SubCommand {
                         p.sendMessage("§6 ▪ §f" + group);
                     }
                 }
-
                 return true;
-
             default:
-
                 sendArenaGroupCmdList(p);
-
                 return true;
         }
     }


### PR DESCRIPTION
- Replaces to ternary operator for List of arena groups
- "/bw arenaGroup list" showed help command list and needed one more argument for show the group list (You can test it with actual version. /bw arenagroup list)
- The command /bw list doesn't exist. Bukkit#dispatchCommand("/bw list") 