### PR TITLE
Do not remove death message unless player is in a game

### DIFF
--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/DamageDeathMove.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/DamageDeathMove.java
@@ -322,10 +322,12 @@ public class DamageDeathMove implements Listener {
 
     @EventHandler
     public void onDeath(PlayerDeathEvent e) {
-        e.setDeathMessage(null);
         Player victim = e.getEntity(), killer = e.getEntity().getKiller();
         ITeam killersTeam = null;
         IArena a = Arena.getArenaByPlayer(victim);
+        if ((BedWars.getServerType() == ServerType.MULTIARENA && BedWars.getLobbyWorld().equals(e.getEntity().getWorld().getName())) || a != null) {
+            e.setDeathMessage(null);
+        }
         if (a != null) {
             if (a.isSpectator(victim)) {
                 victim.spigot().respawn();


### PR DESCRIPTION
This PR just changes the PlayerDeathEvent listener so that it doesn't remove the death message unless the player is actually in a game.