### PR TITLE
Add %bw1058_player_status%

### DIFF
--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/support/papi/PAPISupport.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/support/papi/PAPISupport.java
@@ -203,6 +203,30 @@ public class PAPISupport extends PlaceholderExpansion {
             case "player_rerq_xp":
                 replay = String.valueOf(BedWars.getLevelSupport().getRequiredXp(player));
                 break;
+            case "player_status":
+                if(a != null) {
+                    switch (a.getStatus()) {
+                        case waiting:
+                        case starting:
+                            replay = "WAITING";
+                            break;
+                        case playing:
+                            if(a.isPlayer(player)) {
+                                replay = "PLAYING";
+                            } else if(a.isSpectator(player)) {
+                                replay = "SPECTATING";
+                            } else {
+                                replay = "IN_GAME_BUT_NOT"; // this shouldnt happen
+                            }
+                            break;
+                        case restarting:
+                            replay = "RESTARTING";
+                            break;
+                    }
+                } else {
+                    replay = "NONE";
+                }
+                break;
             case "current_arena_group":
                 if (a != null) {
                     replay = a.getGroup();


### PR DESCRIPTION
A placeholder meant to be used for conditional placeholders

The following should be added to the documentation once this is merged:

```md
## Player Status
This return's the player's status. Meant for conditional placeholders

<details><summary>Values</summary>

`NONE` - The player is not in an arena at all<br/>
`WAITING` - The player is in a waiting lobby, waiting for the game to start<br/>
`PLAYING` - The player is playing (not spectating)<br/>
`SPECTATING` - The player is spectating

</details>

Placeholder: `%bw1058_player_status%`
```