### PR TITLE
Ender Pearl sound on hit block

### DIFF
--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/BedWars.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/BedWars.java
@@ -290,7 +290,7 @@ public class BedWars extends JavaPlugin {
             }, 1L);
 
         // Register events
-        registerEvents(new QuitAndTeleportListener(), new BreakPlace(), new DamageDeathMove(), new Inventory(), new Interact(), new RefreshGUI(), new HungerWeatherSpawn(), new CmdProcess(),
+        registerEvents(new EnderPearlLanded(), new QuitAndTeleportListener(), new BreakPlace(), new DamageDeathMove(), new Inventory(), new Interact(), new RefreshGUI(), new HungerWeatherSpawn(), new CmdProcess(),
                 new FireballListener(), new EggBridge(), new SpectatorListeners(), new BaseListener(), new TargetListener(), new LangListener(), new Warnings(this), new ChatAFK());
         if (getServerType() == ServerType.BUNGEE) {
             if (autoscale) {

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/configuration/Sounds.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/configuration/Sounds.java
@@ -80,6 +80,7 @@ public class Sounds {
         addDefSound("trap-sound", BedWars.getForCurrentVersion("ENDERMAN_TELEPORT", "ENDERMAN_TELEPORT", "ENTITY_ENDERMAN_TELEPORT"));
         addDefSound("shop-auto-equip", BedWars.getForCurrentVersion("HORSE_ARMOR", "ITEM_ARMOR_EQUIP_GENERIC", "ITEM_ARMOR_EQUIP_GENERIC"));
         addDefSound("egg-bridge-block", BedWars.getForCurrentVersion("CHICKEN_EGG_POP", "ENTITY_CHICKEN_EGG", "ENTITY_CHICKEN_EGG"));
+        addDefSound("ender-pearl-landed", BedWars.getForCurrentVersion("ENDERMAN_TELEPORT", "ENTITY_ENDERMEN_TELEPORT", "ENTITY_ENDERMAN_TELEPORT"));
         yml.options().copyDefaults(true);
 
         // remove old paths

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/EnderPearlLanded.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/EnderPearlLanded.java
@@ -1,0 +1,28 @@
+package com.andrei1058.bedwars.listeners;
+
+import com.andrei1058.bedwars.api.arena.IArena;
+import com.andrei1058.bedwars.arena.Arena;
+import com.andrei1058.bedwars.configuration.Sounds;
+import org.bukkit.Sound;
+import org.bukkit.entity.EnderPearl;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.ProjectileHitEvent;
+
+public class EnderPearlLanded implements Listener {
+
+    @EventHandler
+    public void onPearlHit(ProjectileHitEvent e){
+
+        if (!(e.getEntity() instanceof EnderPearl)) return;
+        if (!(e.getEntity().getShooter() instanceof Player)) return;
+
+        Player player = (Player) e.getEntity().getShooter();
+        IArena iArena = Arena.getArenaByPlayer(player);
+
+        if (!Arena.isInArena(player) || iArena.isSpectator(player)) return;
+
+        Sounds.playSound("ender-pearl-landed", iArena.getPlayers());
+    }
+}


### PR DESCRIPTION
Implements a sound for arena players when the ender pearl is hit on a block.

The enhancement request was deleted, I guess.