### PR TITLE
Make firetick disabled by default

### DIFF
--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/configuration/ArenaConfig.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/configuration/ArenaConfig.java
@@ -59,6 +59,7 @@ public class ArenaConfig extends ConfigManager {
         rules.add("doInsomnia:false");
         rules.add("doImmediateRespawn:true");
         rules.add("doWeatherCycle:false");
+        rules.add("doFireTick:false");
         yml.addDefault(ConfigPath.ARENA_GAME_RULES, rules);
         yml.options().copyDefaults(true);
         save();


### PR DESCRIPTION
Makes the doFireTick gamerule `false` by default.

This can of course still be re-enabled in the arena config.