### PR TITLE
Summary message (changes applied)

### DIFF
--- a/bedwars-api/src/main/java/com/andrei1058/bedwars/api/events/player/PlayerMoneyGainEvent.java
+++ b/bedwars-api/src/main/java/com/andrei1058/bedwars/api/events/player/PlayerMoneyGainEvent.java
@@ -1,0 +1,47 @@
+package com.andrei1058.bedwars.api.events.player;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+public class PlayerMoneyGainEvent extends Event {
+
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    private final Player player;
+    private final int amount;
+
+    /**
+     * Called when a player receives money in-game.
+     *
+     * @param player   - target player.
+     * @param amount   - amount of money.
+     */
+    public PlayerMoneyGainEvent(Player player, int amount) {
+        this.player = player;
+        this.amount = amount;
+    }
+
+    /**
+     * Get the player that have received the money.
+     */
+    public Player getPlayer() {
+        return player;
+    }
+
+    /**
+     * Get the amount of money received.
+     */
+    public int getAmount() {
+        return amount;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+}

--- a/bedwars-api/src/main/java/com/andrei1058/bedwars/api/language/Messages.java
+++ b/bedwars-api/src/main/java/com/andrei1058/bedwars/api/language/Messages.java
@@ -272,6 +272,7 @@ public class Messages {
     public static String GAME_END_VICTORY_PLAYER_TITLE = "game-end-victory-title";
     public static String GAME_END_TOP_PLAYER_CHAT = "game-end-top-chat";
     public static String GAME_END_TEAM_WON_CHAT = "game-end-winner-team";
+    public static String GAME_END_PLAYER_REWARD_SUMMARY = "game-end-player-reward-summary";
     public static String XP_REWARD_WIN = "xp-reward-game-win";
     public static String XP_REWARD_PER_TEAMMATE = "xp-reward-per-teammate";
     public static String XP_REWARD_PER_MINUTE = "xp-reward-per-minute";

--- a/bedwars-api/src/main/java/com/andrei1058/bedwars/api/levels/Level.java
+++ b/bedwars-api/src/main/java/com/andrei1058/bedwars/api/levels/Level.java
@@ -50,6 +50,11 @@ public interface Level {
     String getProgressBar(Player p);
 
     /**
+     * @return current long progress bar.
+     */
+    String getLongProgressBar(Player p);
+
+    /**
      * @return current xp.
      */
     int getCurrentXp(Player p);

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/BedWars.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/BedWars.java
@@ -290,7 +290,7 @@ public class BedWars extends JavaPlugin {
             }, 1L);
 
         // Register events
-        registerEvents(new RewardSummary(), new QuitAndTeleportListener(), new BreakPlace(), new DamageDeathMove(), new Inventory(), new Interact(), new RefreshGUI(), new HungerWeatherSpawn(), new CmdProcess(),
+        registerEvents(new RewardSummary(), new EnderPearlLanded(), new QuitAndTeleportListener(), new BreakPlace(), new DamageDeathMove(), new Inventory(), new Interact(), new RefreshGUI(), new HungerWeatherSpawn(), new CmdProcess(),
                 new FireballListener(), new EggBridge(), new SpectatorListeners(), new BaseListener(), new TargetListener(), new LangListener(), new Warnings(this), new ChatAFK());
         if (getServerType() == ServerType.BUNGEE) {
             if (autoscale) {

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/BedWars.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/BedWars.java
@@ -290,7 +290,7 @@ public class BedWars extends JavaPlugin {
             }, 1L);
 
         // Register events
-        registerEvents(new QuitAndTeleportListener(), new BreakPlace(), new DamageDeathMove(), new Inventory(), new Interact(), new RefreshGUI(), new HungerWeatherSpawn(), new CmdProcess(),
+        registerEvents(new RewardSummary(), new QuitAndTeleportListener(), new BreakPlace(), new DamageDeathMove(), new Inventory(), new Interact(), new RefreshGUI(), new HungerWeatherSpawn(), new CmdProcess(),
                 new FireballListener(), new EggBridge(), new SpectatorListeners(), new BaseListener(), new TargetListener(), new LangListener(), new Warnings(this), new ChatAFK());
         if (getServerType() == ServerType.BUNGEE) {
             if (autoscale) {

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/BedWars.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/BedWars.java
@@ -290,7 +290,7 @@ public class BedWars extends JavaPlugin {
             }, 1L);
 
         // Register events
-        registerEvents(new RewardSummary(), new EnderPearlLanded(), new QuitAndTeleportListener(), new BreakPlace(), new DamageDeathMove(), new Inventory(), new Interact(), new RefreshGUI(), new HungerWeatherSpawn(), new CmdProcess(),
+        registerEvents(new EnderPearlLanded(), new RewardSummary(), new QuitAndTeleportListener(), new BreakPlace(), new DamageDeathMove(), new Inventory(), new Interact(), new RefreshGUI(), new HungerWeatherSpawn(), new CmdProcess(),
                 new FireballListener(), new EggBridge(), new SpectatorListeners(), new BaseListener(), new TargetListener(), new LangListener(), new Warnings(this), new ChatAFK());
         if (getServerType() == ServerType.BUNGEE) {
             if (autoscale) {

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/Bangla.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/Bangla.java
@@ -258,6 +258,20 @@ public class Bangla extends Language {
                 "&6                          &lDitio Killer &7- {secondName} - {secondKills}",
                 "&c                          &lTritio Killer &7- {thirdName} - {thirdKills}", "",
                 "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));
+        yml.addDefault(Messages.GAME_END_PLAYER_REWARD_SUMMARY, Arrays.asList("&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬",
+                "&r             &f&lReward Summary",
+                "&r ",
+                "  &7You earned",
+                "   &f&l• &6{coinsEarned} Bed Wars Coins",
+                "&r ",
+                "&r                 &bBed Wars Experience",
+                "&r      &bLevel {level}                             Level {nextLevel}",
+                "&r     {progress}",
+                "&r                 &b{currentXp} &7/ &a{requiredXp} &7({percentAchieved}%)",
+                "&r ",
+                "&7You earned &b{experienceEarned} Bed Wars Experience",
+                "&r ",
+                "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));
         yml.addDefault(Messages.BED_HOLOGRAM_DEFEND, "&c&lApnar Bichana rokkha korun!");
         yml.addDefault(Messages.BED_HOLOGRAM_DESTROYED, "&c&lApnar Bichana dhongso hoye giyeche!");
         yml.addDefault(Messages.NPC_NAME_TEAM_UPGRADES, "&bTEAM UPGRADES,&e&lRIGHT CLICK");

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/English.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/English.java
@@ -257,6 +257,20 @@ public class English extends Language {
                 "&6                          &l2nd Killer &7- {secondName} - {secondKills}",
                 "&c                          &l3rd Killer &7- {thirdName} - {thirdKills}", "",
                 "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));
+        yml.addDefault(Messages.GAME_END_PLAYER_REWARD_SUMMARY, Arrays.asList("&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬",
+                "&r             &f&lReward Summary",
+                "&r ",
+                "  &7You earned",
+                "   &f&l• &6{coinsEarned} Bed Wars Coins",
+                "&r ",
+                "&r                 &bBed Wars Experience",
+                "&r      &bLevel {level}                             Level {nextLevel}",
+                "&r     {progress}",
+                "&r                 &b{currentXp} &7/ &a{requiredXp} &7({percentAchieved}%)",
+                "&r ",
+                "&7You earned &b{experienceEarned} Bed Wars Experience",
+                "&r ",
+                "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));
         yml.addDefault(Messages.BED_HOLOGRAM_DEFEND, "&c&lDefend your bed!");
         yml.addDefault(Messages.BED_HOLOGRAM_DESTROYED, "&c&lYour bed was destroyed!");
         yml.addDefault(Messages.NPC_NAME_TEAM_UPGRADES, "&bTEAM UPGRADES,&e&lRIGHT CLICK");

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/Hindi.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/Hindi.java
@@ -257,6 +257,20 @@ public class Hindi extends Language {
                 "&6                          &lDusra Killer &7- {secondName} - {secondKills}",
                 "&c                          &lTeesra Killer &7- {thirdName} - {thirdKills}", "",
                 "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));
+        yml.addDefault(Messages.GAME_END_PLAYER_REWARD_SUMMARY, Arrays.asList("&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬",
+                "&r             &f&lReward Summary",
+                "&r ",
+                "  &7You earned",
+                "   &f&l• &6{coinsEarned} Bed Wars Coins",
+                "&r ",
+                "&r                 &bBed Wars Experience",
+                "&r      &bLevel {level}                             Level {nextLevel}",
+                "&r     {progress}",
+                "&r                 &b{currentXp} &7/ &a{requiredXp} &7({percentAchieved}%)",
+                "&r ",
+                "&7You earned &b{experienceEarned} Bed Wars Experience",
+                "&r ",
+                "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));
         yml.addDefault(Messages.BED_HOLOGRAM_DEFEND, "&c&lApke bistar ko rakhsha kare!");
         yml.addDefault(Messages.BED_HOLOGRAM_DESTROYED, "&c&lApka bistar tut gaya!");
         yml.addDefault(Messages.NPC_NAME_TEAM_UPGRADES, "&bTEAM UPGRADES,&e&lRIGHT CLICK");

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/Italian.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/Italian.java
@@ -255,6 +255,20 @@ public class Italian extends Language {
                 "&6                          &l2° Uccisore &7- {secondName} - {secondKills}",
                 "&c                          &l3° Uccisore &7- {thirdName} - {thirdKills}", "",
                 "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));
+        yml.addDefault(Messages.GAME_END_PLAYER_REWARD_SUMMARY, Arrays.asList("&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬",
+                "&r             &f&lReward Summary",
+                "&r ",
+                "  &7You earned",
+                "   &f&l• &6{coinsEarned} Bed Wars Coins",
+                "&r ",
+                "&r                 &bBed Wars Experience",
+                "&r      &bLevel {level}                             Level {nextLevel}",
+                "&r     {progress}",
+                "&r                 &b{currentXp} &7/ &a{requiredXp} &7({percentAchieved}%)",
+                "&r ",
+                "&7You earned &b{experienceEarned} Bed Wars Experience",
+                "&r ",
+                "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));
         yml.addDefault(Messages.GAME_END_TEAM_WON_CHAT, "{prefix}{TeamColor}{TeamName} &aha vinto il gioco!");
         yml.addDefault(Messages.BED_HOLOGRAM_DEFEND, "&c&lDifendi il tuo letto!");
         yml.addDefault(Messages.BED_HOLOGRAM_DESTROYED, "&c&lIl tuo letto è stato distrutto!");

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/Persian.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/Persian.java
@@ -258,6 +258,20 @@ public class Persian extends Language {
                 "&6                          &lMagham #2 &7- {secondName} - {secondKills}",
                 "&c                          &lMagham #3 &7- {thirdName} - {thirdKills}", "",
                 "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));
+        yml.addDefault(Messages.GAME_END_PLAYER_REWARD_SUMMARY, Arrays.asList("&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬",
+                "&r             &f&lReward Summary",
+                "&r ",
+                "  &7You earned",
+                "   &f&l• &6{coinsEarned} Bed Wars Coins",
+                "&r ",
+                "&r                 &bBed Wars Experience",
+                "&r      &bLevel {level}                             Level {nextLevel}",
+                "&r     {progress}",
+                "&r                 &b{currentXp} &7/ &a{requiredXp} &7({percentAchieved}%)",
+                "&r ",
+                "&7You earned &b{experienceEarned} Bed Wars Experience",
+                "&r ",
+                "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));
         yml.addDefault(Messages.BED_HOLOGRAM_DEFEND, "&c&lAz Bed khodetoon hefazat konid!");
         yml.addDefault(Messages.BED_HOLOGRAM_DESTROYED, "&c&lBed shoma az bein raft!");
         yml.addDefault(Messages.NPC_NAME_TEAM_UPGRADES, "&bUPGRADE HAYE TEAM,&e&lRIGHT CLICK");

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/Polish.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/Polish.java
@@ -255,6 +255,20 @@ public class Polish extends Language{
                 "&6                       &lTOP 2 Zabojca &7- {secondName} - {secondKills}",
                 "&c                       &lTOP 3 Zabojca &7- {thirdName} - {thirdKills}", "",
                 "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));
+        yml.addDefault(Messages.GAME_END_PLAYER_REWARD_SUMMARY, Arrays.asList("&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬",
+                "&r             &f&lReward Summary",
+                "&r ",
+                "  &7You earned",
+                "   &f&l• &6{coinsEarned} Bed Wars Coins",
+                "&r ",
+                "&r                 &bBed Wars Experience",
+                "&r      &bLevel {level}                             Level {nextLevel}",
+                "&r     {progress}",
+                "&r                 &b{currentXp} &7/ &a{requiredXp} &7({percentAchieved}%)",
+                "&r ",
+                "&7You earned &b{experienceEarned} Bed Wars Experience",
+                "&r ",
+                "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));
         yml.addDefault(Messages.GAME_END_TEAM_WON_CHAT, "{prefix}{TeamColor}{TeamName} &awygral gre!");
         yml.addDefault(Messages.NEXT_EVENT_BEDS_DESTROY, "&dZniszczenie lozek&f:");
         yml.addDefault(Messages.NEXT_EVENT_DIAMOND_UPGRADE_II, "&bDiament &cII&f:");

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/Romanian.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/Romanian.java
@@ -251,6 +251,20 @@ public class Romanian extends Language {
                 "&6                      &lAl 2-lea Ucigas &7- {secondName} - {secondKills}",
                 "&c                      &lAl 3-lea Ucigas &7- {thirdName} - {thirdKills}", "",
                 "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));
+        yml.addDefault(Messages.GAME_END_PLAYER_REWARD_SUMMARY, Arrays.asList("&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬",
+                "&r             &f&lReward Summary",
+                "&r ",
+                "  &7You earned",
+                "   &f&l• &6{coinsEarned} Bed Wars Coins",
+                "&r ",
+                "&r                 &bBed Wars Experience",
+                "&r      &bLevel {level}                             Level {nextLevel}",
+                "&r     {progress}",
+                "&r                 &b{currentXp} &7/ &a{requiredXp} &7({percentAchieved}%)",
+                "&r ",
+                "&7You earned &b{experienceEarned} Bed Wars Experience",
+                "&r ",
+                "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));
         yml.addDefault(Messages.GAME_END_TEAM_WON_CHAT, "{prefix}{TeamColor}Echipa {TeamName} &aa castigat!");
         yml.addDefault(Messages.NPC_NAME_TEAM_UPGRADES, "&bTEAM UPGRADES,&e&lCLICK DREAPTA");
         yml.addDefault(Messages.NPC_NAME_SOLO_UPGRADES, "&bSOLO UPGRADES,&e&lCLICK DREAPTA");

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/Russian.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/Russian.java
@@ -184,6 +184,20 @@ public class Russian extends Language{
                 "&6                          &l2-й Убийца &7- {secondName} - {secondKills}",
                 "&c                          &l3-й Убийца &7- {thirdName} - {thirdKills}", "",
                 "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));
+        yml.addDefault(Messages.GAME_END_PLAYER_REWARD_SUMMARY, Arrays.asList("&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬",
+                "&r             &f&lReward Summary",
+                "&r ",
+                "  &7You earned",
+                "   &f&l• &6{coinsEarned} Bed Wars Coins",
+                "&r ",
+                "&r                 &bBed Wars Experience",
+                "&r      &bLevel {level}                             Level {nextLevel}",
+                "&r     {progress}",
+                "&r                 &b{currentXp} &7/ &a{requiredXp} &7({percentAchieved}%)",
+                "&r ",
+                "&7You earned &b{experienceEarned} Bed Wars Experience",
+                "&r ",
+                "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));
         //yml.addDefault(gameOverReward, Arrays.asList("&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬",
         //        "&f                                   &lReward Summary", "", "",
         //        "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/Spanish.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/Spanish.java
@@ -187,6 +187,20 @@ public class Spanish extends Language{
                 "&6                         &l2do Asesino &7- {secondName} - {secondKills}",
                 "&c                         &l3er Asesino &7- {thirdName} - {thirdKills}", "",
                 "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));
+        yml.addDefault(Messages.GAME_END_PLAYER_REWARD_SUMMARY, Arrays.asList("&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬",
+                "&r             &f&lReward Summary",
+                "&r ",
+                "  &7You earned",
+                "   &f&l• &6{coinsEarned} Bed Wars Coins",
+                "&r ",
+                "&r                 &bBed Wars Experience",
+                "&r      &bLevel {level}                             Level {nextLevel}",
+                "&r     {progress}",
+                "&r                 &b{currentXp} &7/ &a{requiredXp} &7({percentAchieved}%)",
+                "&r ",
+                "&7You earned &b{experienceEarned} Bed Wars Experience",
+                "&r ",
+                "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));
         //yml.addDefault(gameOverReward, Arrays.asList("&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬",
         //        "&f                                   &lReward Summary", "", "",
         //        "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/levels/internal/InternalLevel.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/levels/internal/InternalLevel.java
@@ -47,6 +47,11 @@ public class InternalLevel implements Level {
     }
 
     @Override
+    public String getLongProgressBar(Player p) {
+        return PlayerLevel.getLevelByPlayer(p.getUniqueId()).getLongProgressBar();
+    }
+
+    @Override
     public int getCurrentXp(Player p) {
         return PlayerLevel.getLevelByPlayer(p.getUniqueId()).getCurrentXp();
     }

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/levels/internal/PerMinuteTask.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/levels/internal/PerMinuteTask.java
@@ -44,9 +44,9 @@ public class PerMinuteTask {
             return;
         }
         task = Bukkit.getScheduler().runTaskTimer(BedWars.plugin, () -> {
-            for (Player p : arena.getPlayers()) {
-                PlayerLevel.getLevelByPlayer ( p.getUniqueId () ).addXp ( xp, PlayerXpGainEvent.XpSource.PER_MINUTE );
-                p.sendMessage ( Language.getMsg ( p, Messages.XP_REWARD_PER_MINUTE ).replace ( "{xp}", String.valueOf ( xp ) ) );
+            for (Player player : arena.getPlayers()) {
+                PlayerLevel.getLevelByPlayer(player.getUniqueId()).addXp(xp, PlayerXpGainEvent.XpSource.PER_MINUTE);
+                player.sendMessage(Language.getMsg(player, Messages.XP_REWARD_PER_MINUTE).replace("{xp}", String.valueOf(xp)));
             }
         }, 60 * 20, 60 * 20);
     }

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/levels/internal/PlayerLevel.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/levels/internal/PlayerLevel.java
@@ -39,6 +39,7 @@ public class PlayerLevel {
     private String levelName;
     private int currentXp;
     private String progressBar;
+    private String longProgressBar;
     private String requiredXp;
     private String formattedCurrentXp;
 
@@ -63,6 +64,7 @@ public class PlayerLevel {
         this.level = level;
         this.currentXp = currentXp;
         updateProgressBar();
+        updateLongProgressBar();
         //requiredXp = nextLevelCost >= 1000 ? nextLevelCost % 1000 == 0 ? nextLevelCost / 1000 + "k" : (double) nextLevelCost / 1000 + "k" : String.valueOf(nextLevelCost);
         //formattedCurrentXp = currentXp >= 1000 ? currentXp % 1000 == 0 ? currentXp / 1000 + "k" : (double) currentXp / 1000 + "k" : String.valueOf(currentXp);
         if (!levelByPlayer.containsKey(player)) levelByPlayer.put(player, this);
@@ -103,6 +105,26 @@ public class PlayerLevel {
             unlocked = 0;
         }
         progressBar = ChatColor.translateAlternateColorCodes('&', LevelsConfig.levels.getString("progress-bar.format").replace("{progress}",
+                LevelsConfig.levels.getString("progress-bar.unlocked-color") + String.valueOf(new char[unlocked]).replace("\0", LevelsConfig.levels.getString("progress-bar.symbol"))
+                        + LevelsConfig.levels.getString("progress-bar.locked-color") + String.valueOf(new char[locked]).replace("\0", LevelsConfig.levels.getString("progress-bar.symbol"))));
+        requiredXp = nextLevelCost >= 1000 ? nextLevelCost % 1000 == 0 ? nextLevelCost / 1000 + "k" : (double) nextLevelCost / 1000 + "k" : String.valueOf(nextLevelCost);
+        formattedCurrentXp = currentXp >= 1000 ? currentXp % 1000 == 0 ? currentXp / 1000 + "k" : (double) currentXp / 1000 + "k" : String.valueOf(currentXp);
+    }
+
+    /**
+     * Update the player long progress bar.
+     * This actually only change the amount of symbols.
+     * Could be improved or customized from level.yml
+     */
+    private void updateLongProgressBar() {
+        double l1 = ((nextLevelCost - currentXp) / (double) (nextLevelCost)) * 34;
+        int locked = (int) l1;
+        int unlocked = 34 - locked;
+        if (locked < 0 || unlocked < 0) {
+            locked = 34;
+            unlocked = 0;
+        }
+        longProgressBar = ChatColor.translateAlternateColorCodes('&', LevelsConfig.levels.getString("progress-bar.format").replace("{progress}",
                 LevelsConfig.levels.getString("progress-bar.unlocked-color") + String.valueOf(new char[unlocked]).replace("\0", LevelsConfig.levels.getString("progress-bar.symbol"))
                         + LevelsConfig.levels.getString("progress-bar.locked-color") + String.valueOf(new char[locked]).replace("\0", LevelsConfig.levels.getString("progress-bar.symbol"))));
         requiredXp = nextLevelCost >= 1000 ? nextLevelCost % 1000 == 0 ? nextLevelCost / 1000 + "k" : (double) nextLevelCost / 1000 + "k" : String.valueOf(nextLevelCost);
@@ -159,6 +181,13 @@ public class PlayerLevel {
     }
 
     /**
+     * Get progress long bar for player.
+     */
+    public String getLongProgressBar() {
+        return longProgressBar;
+    }
+
+    /**
      * Get target xp already formatted.
      * Like: 2000 is 2k
      */
@@ -174,6 +203,7 @@ public class PlayerLevel {
         this.currentXp += xp;
         upgradeLevel();
         updateProgressBar();
+        updateLongProgressBar();
         Bukkit.getPluginManager().callEvent(new PlayerXpGainEvent(Bukkit.getPlayer(uuid), xp, source));
         modified = true;
     }
@@ -186,6 +216,7 @@ public class PlayerLevel {
         this.currentXp = currentXp;
         upgradeLevel();
         updateProgressBar();
+        updateLongProgressBar();
         modified = true;
     }
 
@@ -198,6 +229,7 @@ public class PlayerLevel {
         this.levelName = ChatColor.translateAlternateColorCodes('&', LevelsConfig.getLevelName(level)).replace("{number}", String.valueOf(level));
         requiredXp = nextLevelCost >= 1000 ? nextLevelCost % 1000 == 0 ? nextLevelCost / 1000 + "k" : (double) nextLevelCost / 1000 + "k" : String.valueOf(nextLevelCost);
         updateProgressBar();
+        updateLongProgressBar();
         modified = true;
     }
 

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/RewardSummary.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/RewardSummary.java
@@ -1,0 +1,24 @@
+package com.andrei1058.bedwars.listeners;
+
+import com.andrei1058.bedwars.api.events.player.PlayerMoneyGainEvent;
+import com.andrei1058.bedwars.api.events.player.PlayerXpGainEvent;
+import com.andrei1058.bedwars.arena.Arena;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+public class RewardSummary implements Listener {
+
+    @EventHandler
+    public void onGainXp(PlayerXpGainEvent e){
+        if (Arena.getExperienceEarned().containsKey(e.getPlayer().getUniqueId())) {
+            Arena.getExperienceEarned().put(e.getPlayer().getUniqueId(), Arena.getExperienceEarned(e.getPlayer().getUniqueId()) + e.getAmount());
+        }
+    }
+
+    @EventHandler
+    public void onGainMoney(PlayerMoneyGainEvent e){
+        if (Arena.getCoinsEarned().containsKey(e.getPlayer().getUniqueId())) {
+            Arena.getCoinsEarned().put(e.getPlayer().getUniqueId(), Arena.getCoinsEarned(e.getPlayer().getUniqueId()) + e.getAmount());
+        }
+    }
+}

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/money/internal/MoneyListeners.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/money/internal/MoneyListeners.java
@@ -4,6 +4,7 @@ import com.andrei1058.bedwars.BedWars;
 import com.andrei1058.bedwars.api.events.gameplay.GameEndEvent;
 import com.andrei1058.bedwars.api.events.player.PlayerBedBreakEvent;
 import com.andrei1058.bedwars.api.events.player.PlayerKillEvent;
+import com.andrei1058.bedwars.api.events.player.PlayerMoneyGainEvent;
 import com.andrei1058.bedwars.api.language.Language;
 import com.andrei1058.bedwars.api.language.Messages;
 import com.andrei1058.bedwars.configuration.MoneyConfig;
@@ -21,22 +22,25 @@ public class MoneyListeners implements Listener {
      */
     @EventHandler
     public void onGameEnd(GameEndEvent e) {
-        for (UUID p : e.getWinners ()) {
-            Player player = Bukkit.getPlayer ( p );
+        for (UUID uuid : e.getWinners ()) {
+            Player player = Bukkit.getPlayer(uuid);
             if (player == null) continue;
-            int gamewin = MoneyConfig.money.getInt ( "money-rewards.game-win" );
-            if (gamewin > 0) {
-                BedWars.getEconomy ().giveMoney ( player, gamewin );
-                player.sendMessage ( Language.getMsg ( player, Messages.MONEY_REWARD_WIN ).replace ( "{money}", String.valueOf ( gamewin ) ) );
+            int moneyPerWin = MoneyConfig.money.getInt("money-rewards.game-win");
+            if (moneyPerWin > 0) {
+                BedWars.getEconomy().giveMoney(player, moneyPerWin);
+                player.sendMessage(Language.getMsg(player, Messages.MONEY_REWARD_WIN).replace("{money}", String.valueOf(moneyPerWin)));
+                Bukkit.getPluginManager().callEvent(new PlayerMoneyGainEvent(player, moneyPerWin));
             }
         }
-        for (UUID p : e.getLosers ()) {
-            Player player = Bukkit.getPlayer ( p );
+
+        for (UUID uuid : e.getLosers()) {
+            Player player = Bukkit.getPlayer(uuid);
             if (player == null) continue;
-            int teammate = MoneyConfig.money.getInt ( "money-rewards.per-teammate" );
-            if (teammate > 0) {
-                BedWars.getEconomy ().giveMoney ( player, teammate );
-                player.sendMessage ( Language.getMsg ( player, Messages.MONEY_REWARD_PER_TEAMMATE ).replace ( "{money}", String.valueOf ( teammate ) ) );
+            int moneyPerTeammate = MoneyConfig.money.getInt("money-rewards.per-teammate");
+            if (moneyPerTeammate > 0) {
+                BedWars.getEconomy().giveMoney(player, moneyPerTeammate);
+                player.sendMessage(Language.getMsg(player, Messages.MONEY_REWARD_PER_TEAMMATE).replace("{money}", String.valueOf(moneyPerTeammate)));
+                Bukkit.getPluginManager().callEvent(new PlayerMoneyGainEvent(player, moneyPerTeammate));
             }
         }
     }
@@ -46,12 +50,13 @@ public class MoneyListeners implements Listener {
      */
     @EventHandler
     public void onBreakBed(PlayerBedBreakEvent e) {
-        Player player = e.getPlayer ();
+        Player player = e.getPlayer();
         if (player == null) return;
-        int beddestroy = MoneyConfig.money.getInt ( "money-rewards.bed-destroyed" );
-        if (beddestroy > 0) {
-            BedWars.getEconomy ().giveMoney ( player, beddestroy );
-            player.sendMessage ( Language.getMsg ( player, Messages.MONEY_REWARD_BED_DESTROYED ).replace ( "{money}", String.valueOf ( beddestroy ) ) );
+        int moneyPerBedDestroy = MoneyConfig.money.getInt ("money-rewards.bed-destroyed");
+        if (moneyPerBedDestroy > 0) {
+            BedWars.getEconomy().giveMoney(player, moneyPerBedDestroy);
+            player.sendMessage(Language.getMsg(player, Messages.MONEY_REWARD_BED_DESTROYED).replace("{money}", String.valueOf(moneyPerBedDestroy)));
+            Bukkit.getPluginManager().callEvent(new PlayerMoneyGainEvent(player, moneyPerBedDestroy));
         }
     }
 
@@ -60,20 +65,22 @@ public class MoneyListeners implements Listener {
      */
     @EventHandler
     public void onKill(PlayerKillEvent e) {
-        Player player = e.getKiller ();
-        Player victim = e.getVictim ();
+        Player player = e.getKiller();
+        Player victim = e.getVictim();
         if (player == null || victim.equals(player)) return;
-        int finalkill = MoneyConfig.money.getInt ( "money-rewards.final-kill" );
-        int regularkill = MoneyConfig.money.getInt ( "money-rewards.regular-kill" );
-        if (e.getCause ().isFinalKill ()) {
-            if (finalkill > 0) {
-                BedWars.getEconomy ().giveMoney ( player, finalkill );
-                player.sendMessage ( Language.getMsg ( player, Messages.MONEY_REWARD_FINAL_KILL ).replace ( "{money}", String.valueOf ( finalkill ) ) );
+        int moneyPerFinalKill = MoneyConfig.money.getInt("money-rewards.final-kill");
+        int moneyPerRegularKill = MoneyConfig.money.getInt ( "money-rewards.regular-kill");
+        if (e.getCause().isFinalKill()) {
+            if (moneyPerFinalKill > 0) {
+                BedWars.getEconomy().giveMoney(player, moneyPerFinalKill);
+                player.sendMessage(Language.getMsg(player, Messages.MONEY_REWARD_FINAL_KILL ).replace("{money}", String.valueOf(moneyPerFinalKill)));
+                Bukkit.getPluginManager().callEvent(new PlayerMoneyGainEvent(player, moneyPerFinalKill));
             }
         } else {
-            if (regularkill > 0) {
-                BedWars.getEconomy ().giveMoney ( player, regularkill );
-                player.sendMessage ( Language.getMsg ( player, Messages.MONEY_REWARD_REGULAR_KILL ).replace ( "{money}", String.valueOf ( regularkill ) ) );
+            if (moneyPerRegularKill > 0) {
+                BedWars.getEconomy().giveMoney(player, moneyPerRegularKill);
+                player.sendMessage(Language.getMsg(player, Messages.MONEY_REWARD_REGULAR_KILL).replace("{money}", String.valueOf(moneyPerRegularKill)));
+                Bukkit.getPluginManager().callEvent(new PlayerMoneyGainEvent(player, moneyPerRegularKill));
             }
         }
     }

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/money/internal/MoneyListeners.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/money/internal/MoneyListeners.java
@@ -27,9 +27,9 @@ public class MoneyListeners implements Listener {
             if (player == null) continue;
             int moneyPerWin = MoneyConfig.money.getInt("money-rewards.game-win");
             if (moneyPerWin > 0) {
+                Bukkit.getPluginManager().callEvent(new PlayerMoneyGainEvent(player, moneyPerWin));
                 BedWars.getEconomy().giveMoney(player, moneyPerWin);
                 player.sendMessage(Language.getMsg(player, Messages.MONEY_REWARD_WIN).replace("{money}", String.valueOf(moneyPerWin)));
-                Bukkit.getPluginManager().callEvent(new PlayerMoneyGainEvent(player, moneyPerWin));
             }
         }
 
@@ -38,9 +38,9 @@ public class MoneyListeners implements Listener {
             if (player == null) continue;
             int moneyPerTeammate = MoneyConfig.money.getInt("money-rewards.per-teammate");
             if (moneyPerTeammate > 0) {
+                Bukkit.getPluginManager().callEvent(new PlayerMoneyGainEvent(player, moneyPerTeammate));
                 BedWars.getEconomy().giveMoney(player, moneyPerTeammate);
                 player.sendMessage(Language.getMsg(player, Messages.MONEY_REWARD_PER_TEAMMATE).replace("{money}", String.valueOf(moneyPerTeammate)));
-                Bukkit.getPluginManager().callEvent(new PlayerMoneyGainEvent(player, moneyPerTeammate));
             }
         }
     }
@@ -54,9 +54,9 @@ public class MoneyListeners implements Listener {
         if (player == null) return;
         int moneyPerBedDestroy = MoneyConfig.money.getInt ("money-rewards.bed-destroyed");
         if (moneyPerBedDestroy > 0) {
+            Bukkit.getPluginManager().callEvent(new PlayerMoneyGainEvent(player, moneyPerBedDestroy));
             BedWars.getEconomy().giveMoney(player, moneyPerBedDestroy);
             player.sendMessage(Language.getMsg(player, Messages.MONEY_REWARD_BED_DESTROYED).replace("{money}", String.valueOf(moneyPerBedDestroy)));
-            Bukkit.getPluginManager().callEvent(new PlayerMoneyGainEvent(player, moneyPerBedDestroy));
         }
     }
 
@@ -72,15 +72,15 @@ public class MoneyListeners implements Listener {
         int moneyPerRegularKill = MoneyConfig.money.getInt ( "money-rewards.regular-kill");
         if (e.getCause().isFinalKill()) {
             if (moneyPerFinalKill > 0) {
+                Bukkit.getPluginManager().callEvent(new PlayerMoneyGainEvent(player, moneyPerFinalKill));
                 BedWars.getEconomy().giveMoney(player, moneyPerFinalKill);
                 player.sendMessage(Language.getMsg(player, Messages.MONEY_REWARD_FINAL_KILL ).replace("{money}", String.valueOf(moneyPerFinalKill)));
-                Bukkit.getPluginManager().callEvent(new PlayerMoneyGainEvent(player, moneyPerFinalKill));
             }
         } else {
             if (moneyPerRegularKill > 0) {
+                Bukkit.getPluginManager().callEvent(new PlayerMoneyGainEvent(player, moneyPerRegularKill));
                 BedWars.getEconomy().giveMoney(player, moneyPerRegularKill);
                 player.sendMessage(Language.getMsg(player, Messages.MONEY_REWARD_REGULAR_KILL).replace("{money}", String.valueOf(moneyPerRegularKill)));
-                Bukkit.getPluginManager().callEvent(new PlayerMoneyGainEvent(player, moneyPerRegularKill));
             }
         }
     }


### PR DESCRIPTION
**Sorry about the old pr, I don't know what happened (I'm new to using Github to contribute).**

This implements the summary message and closes #206 

- New maps for keep the current coins and experience earned until game end. It's unnecessary create classes for this (I guess).
- These maps are loaded on player join and destroyed on player leave.
- These maps are updated on addXp method and MoneyListeners methods.
- The message is implemented below of top killers message.
- The radical implements of "long progress bar" is for use in chat. The shorter progress bar it looks very ugly in the rewards summary message. This could be improved or customized from level.yml in the future.

**UPDATE:**
Well, I have made use of the PlayerXpGainEvent event to update the experience gained in the course of the game. On the other hand a new event is created "PlayerMoneyGainEvent" that fulfills the same function, to update the money earned. This event is called in each method that money is given to the player.

_Is there a better way to store the experience and money earned instead of a static hashmap?_

Also remove odd spaces, improve some variable names to follow Java conventions and make the code more homogeneous with respect to other variables.

![Screenshot_8](https://user-images.githubusercontent.com/63428864/152748013-451a8f18-bd66-4c6f-b202-53e435c6d208.png)

In 1.8 the bar looks weird, I don't know the reason....