### PR TITLE
"Fix" unbreakable swords

### DIFF
--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/shop/main/BuyItem.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/shop/main/BuyItem.java
@@ -228,12 +228,13 @@ public class BuyItem implements IBuyItem {
                     for (TeamEnchant e : arena.getTeam(player).getBowsEnchantments()) {
                         im.addEnchant(e.getEnchantment(), e.getAmplifier(), true);
                     }
+                    BedWars.nms.setUnbreakable(im);
                 } else if (nms.isSword(i) || nms.isAxe(i)) {
                     for (TeamEnchant e : arena.getTeam(player).getSwordsEnchantments()) {
                         im.addEnchant(e.getEnchantment(), e.getAmplifier(), true);
                     }
+                    BedWars.nms.setUnbreakable(im);
                 }
-                BedWars.nms.setUnbreakable(im);
                 i.setItemMeta(im);
             }
 

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/shop/main/BuyItem.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/shop/main/BuyItem.java
@@ -224,10 +224,7 @@ public class BuyItem implements IBuyItem {
             ItemMeta im = i.getItemMeta();
             i = nms.colourItem(i, arena.getTeam(player));
             if (im != null) {
-                if (permanent) nms.setUnbreakable(im);
-
                 if (i.getType() == Material.BOW) {
-                    if (permanent) nms.setUnbreakable(im);
                     for (TeamEnchant e : arena.getTeam(player).getBowsEnchantments()) {
                         im.addEnchant(e.getEnchantment(), e.getAmplifier(), true);
                     }
@@ -236,6 +233,7 @@ public class BuyItem implements IBuyItem {
                         im.addEnchant(e.getEnchantment(), e.getAmplifier(), true);
                     }
                 }
+                BedWars.nms.setUnbreakable(im);
                 i.setItemMeta(im);
             }
 


### PR DESCRIPTION
This more than a fix is a correction, if you set "true" the condition "is-permanent" in shop.yml then the sword will be unbreakable, otherwise not. This does not work like that because it should be unbreakable anyway, a player will not use the sword until it breaks because it will die sooner or later.

Closes #370 