### PR TITLE
[enhancement] Fix Invisibility Potions on 1.8 and some cosmetic changes

### DIFF
--- a/bedwars-api/src/main/java/com/andrei1058/bedwars/api/events/spectator/SpectatorFirstPersonEnterEvent.java
+++ b/bedwars-api/src/main/java/com/andrei1058/bedwars/api/events/spectator/SpectatorFirstPersonEnterEvent.java
@@ -43,8 +43,8 @@ public class SpectatorFirstPersonEnterEvent extends Event implements Cancellable
     private Function<Player, String> title;
     private Function<Player, String> subTitle;
     private int fadeIn = 0;
-    private int stay = 30;
-    private int fadeOut = 0;
+    private int stay = 40;
+    private int fadeOut = 10;
 
     // A list of all players spectating in first person
     private static List<UUID> spectatingInFirstPerson = new ArrayList<>();

--- a/bedwars-api/src/main/java/com/andrei1058/bedwars/api/events/spectator/SpectatorFirstPersonLeaveEvent.java
+++ b/bedwars-api/src/main/java/com/andrei1058/bedwars/api/events/spectator/SpectatorFirstPersonLeaveEvent.java
@@ -36,8 +36,8 @@ public class SpectatorFirstPersonLeaveEvent extends Event {
     private Function<Player, String> title;
     private Function<Player, String> subTitle;
     private int fadeIn = 0;
-    private int stay = 30;
-    private int fadeOut = 0;
+    private int stay = 40;
+    private int fadeOut = 10;
 
     public SpectatorFirstPersonLeaveEvent(Player spectator, IArena arena, Function<Player, String> title, Function<Player, String> subtitle) {
         this.spectator = spectator;

--- a/bedwars-api/src/main/java/com/andrei1058/bedwars/api/server/VersionSupport.java
+++ b/bedwars-api/src/main/java/com/andrei1058/bedwars/api/server/VersionSupport.java
@@ -131,6 +131,11 @@ public abstract class VersionSupport {
     public abstract boolean isProjectile(ItemStack itemStack);
 
     /**
+     * Check if itemstack is Invisibility Potion
+     */
+    public abstract boolean isInvisibilityPotion(ItemStack itemStack);
+
+    /**
      * Register custom entities
      */
     public abstract void registerEntities();

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/Arena.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/Arena.java
@@ -1442,7 +1442,7 @@ public class Arena implements IArena {
         if (this.status == GameState.starting && status == GameState.waiting) {
             for (Player player : getPlayers()) {
                 Language playerLang = Language.getPlayerLanguage(player);
-                nms.sendTitle(player, playerLang.m(Messages.ARENA_STATUS_START_COUNTDOWN_CANCELLED_TITLE), playerLang.m(Messages.ARENA_STATUS_START_COUNTDOWN_CANCELLED_SUB_TITLE), 0, 40, 0);
+                nms.sendTitle(player, playerLang.m(Messages.ARENA_STATUS_START_COUNTDOWN_CANCELLED_TITLE), playerLang.m(Messages.ARENA_STATUS_START_COUNTDOWN_CANCELLED_SUB_TITLE), 0, 40, 10);
             }
         }
         this.status = status;
@@ -1848,7 +1848,7 @@ public class Arena implements IArena {
                     //noinspection deprecation
                     for (Player p : winner.getMembersCache()) {
                         if (p.getWorld().equals(getWorld())) {
-                            nms.sendTitle(p, getMsg(p, Messages.GAME_END_VICTORY_PLAYER_TITLE), null, 0, 70, 0);
+                            nms.sendTitle(p, getMsg(p, Messages.GAME_END_VICTORY_PLAYER_TITLE), null, 0, 70, 20);
                         }
                         if (!winners.toString().contains(p.getDisplayName())) {
                             winners.append(p.getDisplayName()).append(" ");
@@ -1901,7 +1901,7 @@ public class Arena implements IArena {
                         p.sendMessage(getMsg(p, Messages.GAME_END_TEAM_WON_CHAT).replace("{TeamColor}", winner.getColor().chat().toString())
                                 .replace("{TeamName}", winner.getDisplayName(Language.getPlayerLanguage(p))));
                         if (!winner.getMembers().contains(p)) {
-                            nms.sendTitle(p, getMsg(p, Messages.GAME_END_GAME_OVER_PLAYER_TITLE), null, 0, 70, 0);
+                            nms.sendTitle(p, getMsg(p, Messages.GAME_END_GAME_OVER_PLAYER_TITLE), null, 0, 70, 20);
                         }
                         for (String s : getList(p, Messages.GAME_END_TOP_PLAYER_CHAT)) {
                             String message = s.replace("{firstName}", firstName.isEmpty() ? getMsg(p, Messages.MEANING_NOBODY) : firstName).replace("{firstKills}", String.valueOf(first))

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/tasks/GamePlayingTask.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/tasks/GamePlayingTask.java
@@ -109,11 +109,11 @@ public class GamePlayingTask implements Runnable, PlayingTask {
                 beds_destroy_countdown--;
                 if (getBedsDestroyCountdown() == 0) {
                     for (Player p : getArena().getPlayers()) {
-                        nms.sendTitle(p, getMsg(p, Messages.NEXT_EVENT_TITLE_ANNOUNCE_BEDS_DESTROYED), getMsg(p, Messages.NEXT_EVENT_SUBTITLE_ANNOUNCE_BEDS_DESTROYED), 0, 30, 0);
+                        nms.sendTitle(p, getMsg(p, Messages.NEXT_EVENT_TITLE_ANNOUNCE_BEDS_DESTROYED), getMsg(p, Messages.NEXT_EVENT_SUBTITLE_ANNOUNCE_BEDS_DESTROYED), 0, 40, 10);
                         p.sendMessage(getMsg(p, Messages.NEXT_EVENT_CHAT_ANNOUNCE_BEDS_DESTROYED));
                     }
                     for (Player p : getArena().getSpectators()) {
-                        nms.sendTitle(p, getMsg(p, Messages.NEXT_EVENT_TITLE_ANNOUNCE_BEDS_DESTROYED), getMsg(p, Messages.NEXT_EVENT_SUBTITLE_ANNOUNCE_BEDS_DESTROYED), 0, 30, 0);
+                        nms.sendTitle(p, getMsg(p, Messages.NEXT_EVENT_TITLE_ANNOUNCE_BEDS_DESTROYED), getMsg(p, Messages.NEXT_EVENT_SUBTITLE_ANNOUNCE_BEDS_DESTROYED), 0, 40, 10);
                         p.sendMessage(getMsg(p, Messages.NEXT_EVENT_CHAT_ANNOUNCE_BEDS_DESTROYED));
                     }
                     for (ITeam t : getArena().getTeams()) {
@@ -126,7 +126,7 @@ public class GamePlayingTask implements Runnable, PlayingTask {
                 dragon_spawn_countdown--;
                 if (getDragonSpawnCountdown() == 0) {
                     for (Player p : getArena().getPlayers()) {
-                        nms.sendTitle(p, getMsg(p, Messages.NEXT_EVENT_TITLE_ANNOUNCE_SUDDEN_DEATH), getMsg(p, Messages.NEXT_EVENT_SUBTITLE_ANNOUNCE_SUDDEN_DEATH), 0, 30, 0);
+                        nms.sendTitle(p, getMsg(p, Messages.NEXT_EVENT_TITLE_ANNOUNCE_SUDDEN_DEATH), getMsg(p, Messages.NEXT_EVENT_SUBTITLE_ANNOUNCE_SUDDEN_DEATH), 0, 40, 10);
                         for (ITeam t : getArena().getTeams()) {
                             if (t.getMembers().isEmpty()) continue;
                             p.sendMessage(getMsg(p, Messages.NEXT_EVENT_CHAT_ANNOUNCE_SUDDEN_DEATH).replace("{TeamDragons}", String.valueOf(t.getDragons()))
@@ -134,7 +134,7 @@ public class GamePlayingTask implements Runnable, PlayingTask {
                         }
                     }
                     for (Player p : getArena().getSpectators()) {
-                        nms.sendTitle(p, getMsg(p, Messages.NEXT_EVENT_TITLE_ANNOUNCE_SUDDEN_DEATH), getMsg(p, Messages.NEXT_EVENT_SUBTITLE_ANNOUNCE_SUDDEN_DEATH), 0, 30, 0);
+                        nms.sendTitle(p, getMsg(p, Messages.NEXT_EVENT_TITLE_ANNOUNCE_SUDDEN_DEATH), getMsg(p, Messages.NEXT_EVENT_SUBTITLE_ANNOUNCE_SUDDEN_DEATH), 0, 40, 10);
                         for (ITeam t : getArena().getTeams()) {
                             if (t.getMembers().isEmpty()) continue;
                             p.sendMessage(getMsg(p, Messages.NEXT_EVENT_CHAT_ANNOUNCE_SUDDEN_DEATH).replace("{TeamDragons}", String.valueOf(t.getDragons()))
@@ -230,7 +230,7 @@ public class GamePlayingTask implements Runnable, PlayingTask {
                 } else {
                     nms.sendTitle(e.getKey(), getMsg(e.getKey(), Messages.PLAYER_DIE_RESPAWN_TITLE).replace("{time}",
                             String.valueOf(e.getValue())), getMsg(e.getKey(), Messages.PLAYER_DIE_RESPAWN_SUBTITLE).replace("{time}",
-                            String.valueOf(e.getValue())), 0, 30, 0);
+                            String.valueOf(e.getValue())), 0, 30, 10);
                     e.getKey().sendMessage(getMsg(e.getKey(), Messages.PLAYER_DIE_RESPAWN_CHAT).replace("{time}", String.valueOf(e.getValue())));
                     getArena().getRespawnSessions().replace(e.getKey(), e.getValue() - 1);
                 }

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/tasks/GameStartingTask.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/tasks/GameStartingTask.java
@@ -157,7 +157,7 @@ public class GameStartingTask implements Runnable, StartingTask {
             for (Player player : getArena().getPlayers()) {
                 Language playerLang = Language.getPlayerLanguage(player);
                 String[] titleSubtitle = Language.getCountDownTitle(playerLang, getCountdown());
-                nms.sendTitle(player, titleSubtitle[0], titleSubtitle[1], 4, 22, 4);
+                nms.sendTitle(player, titleSubtitle[0], titleSubtitle[1], 0, 20, 10);
                 player.sendMessage(getMsg(player, Messages.ARENA_STATUS_START_COUNTDOWN_CHAT).replace("{time}", String.valueOf(getCountdown())));
             }
         }
@@ -171,7 +171,7 @@ public class GameStartingTask implements Runnable, StartingTask {
                 BedWarsTeam.reSpawnInvulnerability.put(p.getUniqueId(), System.currentTimeMillis() + 2000L);
                 bwt.firstSpawn(p);
                 Sounds.playSound(ConfigPath.SOUND_GAME_START, p);
-                nms.sendTitle(p, getMsg(p, Messages.ARENA_STATUS_START_PLAYER_TITLE), null, 0, 20, 0);
+                nms.sendTitle(p, getMsg(p, Messages.ARENA_STATUS_START_PLAYER_TITLE), null, 0, 30, 10);
                 for (String tut : getList(p, Messages.ARENA_STATUS_START_PLAYER_TUTORIAL)) {
                     p.sendMessage(SupportPAPI.getSupportPAPI().replace(p, tut));
                 }

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/team/BedWarsTeam.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/team/BedWarsTeam.java
@@ -357,7 +357,7 @@ public class BedWarsTeam implements ITeam {
             }
         }, 8L);
 
-        nms.sendTitle(p, getMsg(p, Messages.PLAYER_DIE_RESPAWNED_TITLE), "", 0, 20, 0);
+        nms.sendTitle(p, getMsg(p, Messages.PLAYER_DIE_RESPAWNED_TITLE), "", 0, 20, 10);
 
         sendDefaultInventory(p, false);
         ShopCache sc = ShopCache.getShopCache(p.getUniqueId());

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/commands/bedwars/subcmds/regular/CmdLeave.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/commands/bedwars/subcmds/regular/CmdLeave.java
@@ -84,9 +84,9 @@ public class CmdLeave extends SubCommand {
 
     private static void update(UUID player){
         if (delay.containsKey(player)){
-            delay.replace(player, System.currentTimeMillis() + 2500L);
+            delay.replace(player, System.currentTimeMillis() + 250L);
             return;
         }
-        delay.put(player, System.currentTimeMillis() + 2500L);
+        delay.put(player, System.currentTimeMillis() + 250L);
     }
 }

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/commands/bedwars/subcmds/regular/CmdLeave.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/commands/bedwars/subcmds/regular/CmdLeave.java
@@ -84,9 +84,9 @@ public class CmdLeave extends SubCommand {
 
     private static void update(UUID player){
         if (delay.containsKey(player)){
-            delay.replace(player, System.currentTimeMillis() + 250L);
+            delay.replace(player, System.currentTimeMillis() + 2500L);
             return;
         }
-        delay.put(player, System.currentTimeMillis() + 250L);
+        delay.put(player, System.currentTimeMillis() + 2500L);
     }
 }

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/commands/bedwars/subcmds/sensitive/setup/SetShop.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/commands/bedwars/subcmds/sensitive/setup/SetShop.java
@@ -70,7 +70,7 @@ public class SetShop extends SubCommand {
                 p.spigot().sendMessage(Misc.msgHoverClick(ss.getPrefix() + "Make sure you set the team's spawn first!", ChatColor.WHITE + "Set a team spawn.", "/" + getParent().getName() + " " + getSubCommandName() + " ", ClickEvent.Action.SUGGEST_COMMAND));
                 p.spigot().sendMessage(Misc.msgHoverClick(ss.getPrefix() + "Or if you set the spawn and it wasn't found automatically try using: /bw " + getSubCommandName() + " <team>", "Set a team shop.", "/" + getParent().getName() + " " + getSubCommandName() + " ", ClickEvent.Action.SUGGEST_COMMAND));
                 p.spigot().sendMessage(Misc.msgHoverClick(ss.getPrefix() + "Other use: /bw setShop <teamName>", "Set a team shop.", "/" + getParent().getName() + " " + getSubCommandName() + " ", ClickEvent.Action.SUGGEST_COMMAND));
-                com.andrei1058.bedwars.BedWars.nms.sendTitle(p, " ", ChatColor.RED + "Could not find any nearby team.", 5, 60, 5);
+                com.andrei1058.bedwars.BedWars.nms.sendTitle(p, " ", ChatColor.RED + "Could not find any nearby team.", 0, 60, 10);
                 Sounds.playSound(ConfigPath.SOUNDS_INSUFF_MONEY, p);
             } else {
                 Bukkit.dispatchCommand(s, getParent().getName() + " " + getSubCommandName() + " " + foundTeam);

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/commands/bedwars/subcmds/sensitive/setup/SetUpgrade.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/commands/bedwars/subcmds/sensitive/setup/SetUpgrade.java
@@ -69,7 +69,7 @@ public class SetUpgrade extends SubCommand {
                 p.sendMessage(ss.getPrefix() + ChatColor.RED + "Could not find any nearby team.");
                 p.spigot().sendMessage(Misc.msgHoverClick(ss.getPrefix() + "Make sure you set the team's spawn first!", ChatColor.WHITE + "Set a team spawn.", "/" + getParent().getName() + " " + getSubCommandName() + " ", ClickEvent.Action.SUGGEST_COMMAND));
                 p.spigot().sendMessage(Misc.msgHoverClick(ss.getPrefix() + "Or if you set the spawn and it wasn't found automatically try using: /bw " + getSubCommandName() + " <team>", "Set team upgrades NPC for a team.", "/" + getParent().getName() + " " + getSubCommandName() + " ", ClickEvent.Action.SUGGEST_COMMAND));
-                com.andrei1058.bedwars.BedWars.nms.sendTitle(p, " ", ChatColor.RED + "Could not find any nearby team.", 5, 60, 5);
+                com.andrei1058.bedwars.BedWars.nms.sendTitle(p, " ", ChatColor.RED + "Could not find any nearby team.", 0, 60, 10);
                 Sounds.playSound(ConfigPath.SOUNDS_INSUFF_MONEY, p);
 
             } else {

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/English.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/English.java
@@ -93,7 +93,7 @@ public class English extends Language {
         yml.addDefault(Messages.COMMAND_PARTY_INVITE_SENT_TARGET_RECEIVE_MSG, "{prefix}&b{player} &ehas invited you to a party! &o&7(Click to accept)");
         yml.addDefault(Messages.COMMAND_PARTY_INVITE_DENIED_CANNOT_INVITE_YOURSELF, "{prefix}&cYou cannot invite yourself!");
         yml.addDefault(Messages.COMMAND_PARTY_INVITE_DENIED_PLAYER_OFFLINE, "{prefix}&7{player} &eis offline!");
-        yml.addDefault(Messages.COMMAND_PARTY_ACCEPT_DENIED_NO_INVITE, "{prefix}&cThere's no party requests to accept");
+        yml.addDefault(Messages.COMMAND_PARTY_ACCEPT_DENIED_NO_INVITE, "{prefix}&cThere are no party requests to accept!");
         yml.addDefault(Messages.COMMAND_PARTY_ACCEPT_DENIED_ALREADY_IN_PARTY, "{prefix}&eYou're already in a party!");
         yml.addDefault(Messages.COMMAND_PARTY_INSUFFICIENT_PERMISSIONS, "{prefix}&cOnly the party owner can do this!");
         yml.addDefault(Messages.COMMAND_PARTY_ACCEPT_USAGE, "{prefix}&eUsage: &7/party accept <player>");

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/BreakPlace.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/BreakPlace.java
@@ -310,7 +310,7 @@ public class BreakPlace implements Listener {
                                                             .replace("{PlayerName}", p.getDisplayName()));
                                                 }
                                                 if (breakEvent.getTitle() != null && breakEvent.getSubTitle() != null) {
-                                                    nms.sendTitle(on, breakEvent.getTitle().apply(on), breakEvent.getSubTitle().apply(on), 0, 25, 0);
+                                                    nms.sendTitle(on, breakEvent.getTitle().apply(on), breakEvent.getSubTitle().apply(on), 0, 40, 10);
                                                 }
                                                 if (t.isMember(on)) Sounds.playSound(ConfigPath.SOUNDS_BED_DESTROY_OWN, on);
                                                 else Sounds.playSound(ConfigPath.SOUNDS_BED_DESTROY, on);

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/InvisibilityPotionListener.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/InvisibilityPotionListener.java
@@ -75,45 +75,43 @@ public class InvisibilityPotionListener implements Listener {
                         nms.minusAmount(e.getPlayer(), new ItemStack(Material.GLASS_BOTTLE), 1),
                 5L);
         //
-        PotionMeta pm = (PotionMeta) e.getItem().getItemMeta();
-        if (pm.hasCustomEffects()) {
-            if (pm.hasCustomEffect(PotionEffectType.INVISIBILITY)) {
-                Bukkit.getScheduler().runTaskLater(plugin, () -> {
-                    for (PotionEffect pe : e.getPlayer().getActivePotionEffects()) {
-                        if (pe.getType().toString().contains("INVISIBILITY")) {
-                            // if is already invisible
-                            if (a.getShowTime().containsKey(e.getPlayer())) {
-                                ITeam t = a.getTeam(e.getPlayer());
-                                // increase invisibility timer
-                                // keep trace of invisible players to send hide armor packet when required
-                                // because potions do not hide armors
-                                a.getShowTime().replace(e.getPlayer(), pe.getDuration() / 20);
-                                // call custom event
-                                Bukkit.getPluginManager().callEvent(new PlayerInvisibilityPotionEvent(PlayerInvisibilityPotionEvent.Type.ADDED, t, e.getPlayer(), t.getArena()));
-                            } else {
-                                // if not already invisible
-                                ITeam t = a.getTeam(e.getPlayer());
-                                // keep trace of invisible players to send hide armor packet when required
-                                // because potions do not hide armors
-                                a.getShowTime().put(e.getPlayer(), pe.getDuration() / 20);
-                                //
-                                for (Player p1 : e.getPlayer().getWorld().getPlayers()) {
-                                    if (a.isSpectator(p1)) {
-                                        // hide player armor to spectators
-                                        nms.hideArmor(e.getPlayer(), p1);
-                                    } else if (t != a.getTeam(p1)) {
-                                        // hide player armor to other teams
-                                        nms.hideArmor(e.getPlayer(), p1);
-                                    }
+
+        if (nms.isInvisibilityPotion(e.getItem())) {
+            Bukkit.getScheduler().runTaskLater(plugin, () -> {
+                for (PotionEffect pe : e.getPlayer().getActivePotionEffects()) {
+                    if (pe.getType().toString().contains("INVISIBILITY")) {
+                        // if is already invisible
+                        if (a.getShowTime().containsKey(e.getPlayer())) {
+                            ITeam t = a.getTeam(e.getPlayer());
+                            // increase invisibility timer
+                            // keep trace of invisible players to send hide armor packet when required
+                            // because potions do not hide armors
+                            a.getShowTime().replace(e.getPlayer(), pe.getDuration() / 20);
+                            // call custom event
+                            Bukkit.getPluginManager().callEvent(new PlayerInvisibilityPotionEvent(PlayerInvisibilityPotionEvent.Type.ADDED, t, e.getPlayer(), t.getArena()));
+                        } else {
+                            // if not already invisible
+                            ITeam t = a.getTeam(e.getPlayer());
+                            // keep trace of invisible players to send hide armor packet when required
+                            // because potions do not hide armors
+                            a.getShowTime().put(e.getPlayer(), pe.getDuration() / 20);
+                            //
+                            for (Player p1 : e.getPlayer().getWorld().getPlayers()) {
+                                if (a.isSpectator(p1)) {
+                                    // hide player armor to spectators
+                                    nms.hideArmor(e.getPlayer(), p1);
+                                } else if (t != a.getTeam(p1)) {
+                                    // hide player armor to other teams
+                                    nms.hideArmor(e.getPlayer(), p1);
                                 }
-                                // call custom event
-                                Bukkit.getPluginManager().callEvent(new PlayerInvisibilityPotionEvent(PlayerInvisibilityPotionEvent.Type.ADDED, t, e.getPlayer(), t.getArena()));
                             }
-                            break;
+                            // call custom event
+                            Bukkit.getPluginManager().callEvent(new PlayerInvisibilityPotionEvent(PlayerInvisibilityPotionEvent.Type.ADDED, t, e.getPlayer(), t.getArena()));
                         }
+                        break;
                     }
-                }, 5L);
-            }
+                }
+            }, 5L);
         }
     }
 }

--- a/versionsupport_1_10_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_10_R1/v1_10_R1.java
+++ b/versionsupport_1_10_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_10_R1/v1_10_R1.java
@@ -207,6 +207,15 @@ public class v1_10_R1 extends VersionSupport {
     }
 
     @Override
+    public boolean isInvisibilityPotion(org.bukkit.inventory.ItemStack itemStack) {
+        if (!itemStack.getType().equals(org.bukkit.Material.POTION)) return false;
+
+        org.bukkit.inventory.meta.PotionMeta pm = (org.bukkit.inventory.meta.PotionMeta) itemStack.getItemMeta();
+
+        return pm.hasCustomEffects() && pm.hasCustomEffect(org.bukkit.potion.PotionEffectType.INVISIBILITY);
+    }
+
+    @Override
     public void registerEntities() {
         registerEntity("Silverfish2", 60, Silverfish.class);
         registerEntity("IGolem", 99, IGolem.class);

--- a/versionsupport_1_11_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_11_R1/v1_11_R1.java
+++ b/versionsupport_1_11_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_11_R1/v1_11_R1.java
@@ -211,6 +211,15 @@ public class v1_11_R1 extends VersionSupport {
     }
 
     @Override
+    public boolean isInvisibilityPotion(org.bukkit.inventory.ItemStack itemStack) {
+        if (!itemStack.getType().equals(org.bukkit.Material.POTION)) return false;
+
+        org.bukkit.inventory.meta.PotionMeta pm = (org.bukkit.inventory.meta.PotionMeta) itemStack.getItemMeta();
+
+        return pm.hasCustomEffects() && pm.hasCustomEffect(org.bukkit.potion.PotionEffectType.INVISIBILITY);
+    }
+
+    @Override
     public void registerEntities() {
 
     }

--- a/versionsupport_1_12_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_12_R1/v1_12_R1.java
+++ b/versionsupport_1_12_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_12_R1/v1_12_R1.java
@@ -212,6 +212,15 @@ public class v1_12_R1 extends VersionSupport {
     }
 
     @Override
+    public boolean isInvisibilityPotion(org.bukkit.inventory.ItemStack itemStack) {
+        if (!itemStack.getType().equals(org.bukkit.Material.POTION)) return false;
+
+        org.bukkit.inventory.meta.PotionMeta pm = (org.bukkit.inventory.meta.PotionMeta) itemStack.getItemMeta();
+
+        return pm.hasCustomEffects() && pm.hasCustomEffect(org.bukkit.potion.PotionEffectType.INVISIBILITY);
+    }
+
+    @Override
     public void registerEntities() {
         registerEntity("Silverfish2", 60, Silverfish.class);
         registerEntity("IGolem", 99, IGolem.class);

--- a/versionsupport_1_13_R2/src/main/java/com/andrei1058/bedwars/support/version/v1_13_R2/v1_13_R2.java
+++ b/versionsupport_1_13_R2/src/main/java/com/andrei1058/bedwars/support/version/v1_13_R2/v1_13_R2.java
@@ -212,6 +212,15 @@ public class v1_13_R2 extends VersionSupport {
         return CraftItemStack.asNMSCopy(itemStack).getItem() instanceof IProjectile;
     }
 
+    @Override
+    public boolean isInvisibilityPotion(org.bukkit.inventory.ItemStack itemStack) {
+        if (!itemStack.getType().equals(org.bukkit.Material.POTION)) return false;
+
+        org.bukkit.inventory.meta.PotionMeta pm = (org.bukkit.inventory.meta.PotionMeta) itemStack.getItemMeta();
+
+        return pm != null && pm.hasCustomEffects() && pm.hasCustomEffect(org.bukkit.potion.PotionEffectType.INVISIBILITY);
+    }
+
     @SuppressWarnings("unchecked")
     @Override
     public void registerEntities() {

--- a/versionsupport_1_14_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_14_R1/v1_14_R1.java
+++ b/versionsupport_1_14_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_14_R1/v1_14_R1.java
@@ -212,6 +212,15 @@ public class v1_14_R1 extends VersionSupport {
         return CraftItemStack.asNMSCopy(itemStack).getItem() instanceof IProjectile;
     }
 
+    @Override
+    public boolean isInvisibilityPotion(org.bukkit.inventory.ItemStack itemStack) {
+        if (!itemStack.getType().equals(org.bukkit.Material.POTION)) return false;
+
+        org.bukkit.inventory.meta.PotionMeta pm = (org.bukkit.inventory.meta.PotionMeta) itemStack.getItemMeta();
+
+        return pm != null && pm.hasCustomEffects() && pm.hasCustomEffect(org.bukkit.potion.PotionEffectType.INVISIBILITY);
+    }
+
     @SuppressWarnings({"unchecked", "ResultOfMethodCallIgnored"})
     @Override
     public void registerEntities() {

--- a/versionsupport_1_15_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_15_R1/v1_15_R1.java
+++ b/versionsupport_1_15_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_15_R1/v1_15_R1.java
@@ -211,6 +211,15 @@ public class v1_15_R1 extends VersionSupport {
         return CraftItemStack.asNMSCopy(itemStack).getItem() instanceof IProjectile;
     }
 
+    @Override
+    public boolean isInvisibilityPotion(org.bukkit.inventory.ItemStack itemStack) {
+        if (!itemStack.getType().equals(org.bukkit.Material.POTION)) return false;
+
+        org.bukkit.inventory.meta.PotionMeta pm = (org.bukkit.inventory.meta.PotionMeta) itemStack.getItemMeta();
+
+        return pm != null && pm.hasCustomEffects() && pm.hasCustomEffect(org.bukkit.potion.PotionEffectType.INVISIBILITY);
+    }
+
     @SuppressWarnings({"unchecked", "ResultOfMethodCallIgnored"})
     @Override
     public void registerEntities() {

--- a/versionsupport_1_16_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_16_R1/v1_16_R1.java
+++ b/versionsupport_1_16_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_16_R1/v1_16_R1.java
@@ -201,6 +201,15 @@ public class v1_16_R1 extends VersionSupport {
         return CraftItemStack.asNMSCopy(itemStack).A() instanceof IProjectile;
     }
 
+    @Override
+    public boolean isInvisibilityPotion(org.bukkit.inventory.ItemStack itemStack) {
+        if (!itemStack.getType().equals(org.bukkit.Material.POTION)) return false;
+
+        org.bukkit.inventory.meta.PotionMeta pm = (org.bukkit.inventory.meta.PotionMeta) itemStack.getItemMeta();
+
+        return pm != null && pm.hasCustomEffects() && pm.hasCustomEffect(org.bukkit.potion.PotionEffectType.INVISIBILITY);
+    }
+
     @SuppressWarnings({"unchecked"})
     @Override
     public void registerEntities() {

--- a/versionsupport_1_16_R2/src/main/java/com/andrei1058/bedwars/support/version/v1_16_R2/v1_16_R2.java
+++ b/versionsupport_1_16_R2/src/main/java/com/andrei1058/bedwars/support/version/v1_16_R2/v1_16_R2.java
@@ -201,6 +201,15 @@ public class v1_16_R2 extends VersionSupport {
         return CraftItemStack.asNMSCopy(itemStack).A() instanceof IProjectile;
     }
 
+    @Override
+    public boolean isInvisibilityPotion(org.bukkit.inventory.ItemStack itemStack) {
+        if (!itemStack.getType().equals(org.bukkit.Material.POTION)) return false;
+
+        org.bukkit.inventory.meta.PotionMeta pm = (org.bukkit.inventory.meta.PotionMeta) itemStack.getItemMeta();
+
+        return pm != null && pm.hasCustomEffects() && pm.hasCustomEffect(org.bukkit.potion.PotionEffectType.INVISIBILITY);
+    }
+
     @SuppressWarnings({"unchecked"})
     @Override
     public void registerEntities() {

--- a/versionsupport_1_8_R3/src/main/java/com/andrei1058/bedwars/support/version/v1_8_R3/v1_8_R3.java
+++ b/versionsupport_1_8_R3/src/main/java/com/andrei1058/bedwars/support/version/v1_8_R3/v1_8_R3.java
@@ -174,6 +174,22 @@ public class v1_8_R3 extends VersionSupport {
     }
 
     @Override
+    public boolean isInvisibilityPotion(org.bukkit.inventory.ItemStack itemStack) {
+        if (!itemStack.getType().equals(org.bukkit.Material.POTION)) return false;
+
+        org.bukkit.inventory.meta.PotionMeta pm = (org.bukkit.inventory.meta.PotionMeta) itemStack.getItemMeta();
+
+        if (pm != null && pm.hasCustomEffects()) {
+            return pm.hasCustomEffect(org.bukkit.potion.PotionEffectType.INVISIBILITY);
+        }
+
+        org.bukkit.potion.Potion potion = org.bukkit.potion.Potion.fromItemStack(itemStack);
+        org.bukkit.potion.PotionType type = potion.getType();
+
+        return type.getEffectType().equals(org.bukkit.potion.PotionEffectType.INVISIBILITY);
+    }
+
+    @Override
     public void registerEntities() {
         registerEntity("Silverfish2", 60, Silverfish.class);
         registerEntity("IGolem", 99, IGolem.class);

--- a/versionsupport_1_9_R2/src/main/java/com/andrei1058/bedwars/support/version/v1_9_R2/v1_9_R2.java
+++ b/versionsupport_1_9_R2/src/main/java/com/andrei1058/bedwars/support/version/v1_9_R2/v1_9_R2.java
@@ -198,6 +198,15 @@ public class v1_9_R2 extends VersionSupport {
     }
 
     @Override
+    public boolean isInvisibilityPotion(org.bukkit.inventory.ItemStack itemStack) {
+        if (!itemStack.getType().equals(org.bukkit.Material.POTION)) return false;
+
+        org.bukkit.inventory.meta.PotionMeta pm = (org.bukkit.inventory.meta.PotionMeta) itemStack.getItemMeta();
+
+        return pm.hasCustomEffects() && pm.hasCustomEffect(org.bukkit.potion.PotionEffectType.INVISIBILITY);
+    }
+
+    @Override
     public void registerEntities() {
         registerEntity("Silverfish2", 60, Silverfish.class);
         registerEntity("IGolem", 99, IGolem.class);

--- a/versionsupport_v1_16_R3/src/main/java/com/andrei1058/bedwars/support/version/v1_16_R3/v1_16_R3.java
+++ b/versionsupport_v1_16_R3/src/main/java/com/andrei1058/bedwars/support/version/v1_16_R3/v1_16_R3.java
@@ -201,6 +201,15 @@ public class v1_16_R3 extends VersionSupport {
         return CraftItemStack.asNMSCopy(itemStack).A() instanceof IProjectile;
     }
 
+    @Override
+    public boolean isInvisibilityPotion(org.bukkit.inventory.ItemStack itemStack) {
+        if (!itemStack.getType().equals(org.bukkit.Material.POTION)) return false;
+
+        org.bukkit.inventory.meta.PotionMeta pm = (org.bukkit.inventory.meta.PotionMeta) itemStack.getItemMeta();
+
+        return pm != null && pm.hasCustomEffects() && pm.hasCustomEffect(org.bukkit.potion.PotionEffectType.INVISIBILITY);
+    }
+
     @SuppressWarnings({"unchecked"})
     @Override
     public void registerEntities() {

--- a/versionsupport_v1_17_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_17_R1/v1_17_R1.java
+++ b/versionsupport_v1_17_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_17_R1/v1_17_R1.java
@@ -226,6 +226,15 @@ public class v1_17_R1 extends VersionSupport {
         return CraftItemStack.asNMSCopy(itemStack).E() instanceof IProjectile;
     }
 
+    @Override
+    public boolean isInvisibilityPotion(org.bukkit.inventory.ItemStack itemStack) {
+        if (!itemStack.getType().equals(org.bukkit.Material.POTION)) return false;
+
+        org.bukkit.inventory.meta.PotionMeta pm = (org.bukkit.inventory.meta.PotionMeta) itemStack.getItemMeta();
+
+        return pm != null && pm.hasCustomEffects() && pm.hasCustomEffect(org.bukkit.potion.PotionEffectType.INVISIBILITY);
+    }
+
     @SuppressWarnings({"unchecked"})
     @Override
     public void registerEntities() {

--- a/versionsupport_v1_18_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_18_R1/v1_18_R1.java
+++ b/versionsupport_v1_18_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_18_R1/v1_18_R1.java
@@ -225,6 +225,15 @@ public class v1_18_R1 extends VersionSupport {
         return CraftItemStack.asNMSCopy(itemStack).E() instanceof IProjectile;
     }
 
+    @Override
+    public boolean isInvisibilityPotion(org.bukkit.inventory.ItemStack itemStack) {
+        if (!itemStack.getType().equals(org.bukkit.Material.POTION)) return false;
+
+        org.bukkit.inventory.meta.PotionMeta pm = (org.bukkit.inventory.meta.PotionMeta) itemStack.getItemMeta();
+
+        return pm != null && pm.hasCustomEffects() && pm.hasCustomEffect(org.bukkit.potion.PotionEffectType.INVISIBILITY);
+    }
+
     @SuppressWarnings({"unchecked"})
     @Override
     public void registerEntities() {


### PR DESCRIPTION
Fixed invisibility potions:
On 1.8, when drinking an invisibility potion obtained with /gmc, an error occurred due to PotionMeta being empty. 
On 1.8, the way of getting potion info is Potion#fromItemStack().getType();

Cosmetic changes:
- Smoothly fade out titles _(temporary solution, I'll make it configurable from config)_
- Removed too long cooldown on `/bw leave` command, why so long?
- Fixed a grammar error in English language
