### PR TITLE
Made generator protection radius configurable

### DIFF
--- a/bedwars-api/src/main/java/com/andrei1058/bedwars/api/configuration/ConfigPath.java
+++ b/bedwars-api/src/main/java/com/andrei1058/bedwars/api/configuration/ConfigPath.java
@@ -160,6 +160,7 @@ public class ConfigPath {
     public static final String ARENA_SPAWN_PROTECTION = "spawn-protection";
     public static final String ARENA_SHOP_PROTECTION = "shop-protection";
     public static final String ARENA_UPGRADES_PROTECTION = "upgrades-protection";
+    public static final String ARENA_GENERATOR_PROTECTION = "generator-protection";
     public static final String ARENA_DISABLE_GENERATOR_FOR_EMPTY_TEAMS = "disable-generator-for-empty-teams";
     public static final String ARENA_DISABLE_NPCS_FOR_EMPTY_TEAMS = "disable-npcs-for-empty-teams";
     public static final String ARENA_ISLAND_RADIUS = "island-radius";

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/configuration/ArenaConfig.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/configuration/ArenaConfig.java
@@ -43,6 +43,7 @@ public class ArenaConfig extends ConfigManager {
         yml.addDefault(ConfigPath.ARENA_SPAWN_PROTECTION, 5);
         yml.addDefault(ConfigPath.ARENA_SHOP_PROTECTION, 1);
         yml.addDefault(ConfigPath.ARENA_UPGRADES_PROTECTION, 1);
+        yml.addDefault(ConfigPath.ARENA_GENERATOR_PROTECTION, 1);
         yml.addDefault(ConfigPath.ARENA_ISLAND_RADIUS, 17);
         yml.addDefault("worldBorder", 300);
         yml.addDefault(ConfigPath.ARENA_Y_LEVEL_KILL, -1);

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/BreakPlace.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/BreakPlace.java
@@ -463,7 +463,7 @@ public class BreakPlace implements Listener {
                         return;
                     }
                     for (IGenerator o : t.getGenerators()) {
-                        if (o.getLocation().distance(e.getBlockClicked().getLocation()) <= 1) {
+                        if (o.getLocation().distance(e.getBlockClicked().getLocation()) <= a.getConfig().getInt(ConfigPath.ARENA_GENERATOR_PROTECTION)) {
                             e.setCancelled(true);
                             p.sendMessage(getMsg(p, Messages.INTERACT_CANNOT_PLACE_BLOCK));
                             return;
@@ -471,7 +471,7 @@ public class BreakPlace implements Listener {
                     }
                 }
                 for (IGenerator o : a.getOreGenerators()) {
-                    if (o.getLocation().distance(e.getBlockClicked().getLocation()) <= 1) {
+                    if (o.getLocation().distance(e.getBlockClicked().getLocation()) <= a.getConfig().getInt(ConfigPath.ARENA_GENERATOR_PROTECTION)) {
                         e.setCancelled(true);
                         p.sendMessage(getMsg(p, Messages.INTERACT_CANNOT_PLACE_BLOCK));
                         return;


### PR DESCRIPTION
Before it was hardcoded to 1. Now there is an option in the arena config.

closes #411 