### PR TITLE
Allow players to extinguish fire

### DIFF
--- a/bedwars-api/src/main/java/com/andrei1058/bedwars/api/configuration/ConfigPath.java
+++ b/bedwars-api/src/main/java/com/andrei1058/bedwars/api/configuration/ConfigPath.java
@@ -69,6 +69,8 @@ public class ConfigPath {
     public static final String GENERAL_CONFIGURATION_BUNGEE_OPTION_SERVER_ID = "bungee-settings.server-id";
     public static final String GENERAL_CONFIGURATION_BUNGEE_OPTION_BWP_TIME_OUT = "bungee-settings.bwp-time-out";
 
+    public static final String GENERAL_CONFIGURATION_ALLOW_FIRE_EXTINGUISH = "allow-fire-extinguish";
+
     public static final String GENERAL_CONFIGURATION_LOBBY_ITEMS_PATH = "lobby-items";
     public static final String GENERAL_CONFIGURATION_EXPERIMENTAL_TEAM_ASSIGNER = "use-experimental-team-assigner";
 

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/configuration/MainConfig.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/configuration/MainConfig.java
@@ -90,6 +90,9 @@ public class MainConfig extends ConfigManager {
         yml.addDefault(ConfigPath.GENERAL_CONFIG_PLACEHOLDERS_REPLACEMENTS_SERVER_IP, "yourServer.Com");
         yml.addDefault(ConfigPath.GENERAL_CONFIGURATION_BUNGEE_OPTION_SERVER_ID, "bw1");
         yml.addDefault(ConfigPath.GENERAL_CONFIGURATION_BUNGEE_OPTION_BWP_TIME_OUT, 5000);
+
+        yml.addDefault(ConfigPath.GENERAL_CONFIGURATION_ALLOW_FIRE_EXTINGUISH, true);
+
         // tnt jump category
         yml.addDefault(ConfigPath.GENERAL_TNT_JUMP_BARYCENTER_IN_Y, 0.5);
         yml.addDefault(ConfigPath.GENERAL_TNT_JUMP_STRENGTH_REDUCTION, 5);

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/BreakPlace.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/BreakPlace.java
@@ -66,6 +66,11 @@ import static com.andrei1058.bedwars.api.language.Language.getMsg;
 public class BreakPlace implements Listener {
 
     private static final List<Player> buildSession = new ArrayList<>();
+    private final boolean allowFireBreak;
+
+    public BreakPlace() {
+        allowFireBreak = config.getBoolean(ConfigPath.GENERAL_CONFIGURATION_ALLOW_FIRE_EXTINGUISH);
+    }
 
     @EventHandler
     public void onIceMelt(BlockFadeEvent e) {
@@ -258,6 +263,11 @@ public class BreakPlace implements Listener {
                 case "GRASS_PATH":
                 case "DOUBLE_PLANT":
                     if (e.isCancelled()) {
+                        e.setCancelled(false);
+                    }
+                    return;
+                case "FIRE":
+                    if(allowFireBreak) {
                         e.setCancelled(false);
                     }
                     return;

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/BreakPlace.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/BreakPlace.java
@@ -269,8 +269,9 @@ public class BreakPlace implements Listener {
                 case "FIRE":
                     if(allowFireBreak) {
                         e.setCancelled(false);
+                        return;
                     }
-                    return;
+                    break;
             }
 
             if (nms.isBed(e.getBlock().getType())) {


### PR DESCRIPTION
Currently, players cannot put out fire that spreads because it wasnt placed by a fire.

This makes it so players can put out fires in maps

This behavior can be disabled in the config if you prefer the old way.

Closes #414 