### PR TITLE
WIP: Reward Summary system

### DIFF
--- a/bedwars-api/src/main/java/com/andrei1058/bedwars/api/arena/IArena.java
+++ b/bedwars-api/src/main/java/com/andrei1058/bedwars/api/arena/IArena.java
@@ -508,10 +508,10 @@ public interface IArena {
     /**
      * Stored the coins for the player
      */
-    Map<UUID, Integer> getCoinsEarned();
+    Map<UUID, Integer> getCoinsMap();
 
     /**
      * Stored the experience for the player
      */
-    Map<UUID, Integer> getExperienceEarned();
+    Map<UUID, Integer> getExperienceMap();
 }

--- a/bedwars-api/src/main/java/com/andrei1058/bedwars/api/arena/IArena.java
+++ b/bedwars-api/src/main/java/com/andrei1058/bedwars/api/arena/IArena.java
@@ -494,4 +494,12 @@ public interface IArena {
     void setTeamAssigner(ITeamAssigner teamAssigner);
 
     List<Player> getLeavingPlayers();
+
+    int getCoinsEarned(UUID uuid);
+
+    int getExperienceEarned(UUID uuid);
+
+    Map<UUID, Integer> getCoinsEarned();
+
+    Map<UUID, Integer> getExperienceEarned();
 }

--- a/bedwars-api/src/main/java/com/andrei1058/bedwars/api/arena/IArena.java
+++ b/bedwars-api/src/main/java/com/andrei1058/bedwars/api/arena/IArena.java
@@ -495,11 +495,23 @@ public interface IArena {
 
     List<Player> getLeavingPlayers();
 
+    /**
+     * Track the coins earned in-game by the player
+     */
     int getCoinsEarned(UUID uuid);
 
+    /**
+     * Track the experience earned in-game by the player
+     */
     int getExperienceEarned(UUID uuid);
 
+    /**
+     * Stored the coins for the player
+     */
     Map<UUID, Integer> getCoinsEarned();
 
+    /**
+     * Stored the experience for the player
+     */
     Map<UUID, Integer> getExperienceEarned();
 }

--- a/bedwars-api/src/main/java/com/andrei1058/bedwars/api/events/player/PlayerMoneyGainEvent.java
+++ b/bedwars-api/src/main/java/com/andrei1058/bedwars/api/events/player/PlayerMoneyGainEvent.java
@@ -1,0 +1,47 @@
+package com.andrei1058.bedwars.api.events.player;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+public class PlayerMoneyGainEvent extends Event {
+
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    private final Player player;
+    private final int amount;
+
+    /**
+     * Called when a player receives money in-game.
+     *
+     * @param player   - target player.
+     * @param amount   - amount of money.
+     */
+    public PlayerMoneyGainEvent(Player player, int amount) {
+        this.player = player;
+        this.amount = amount;
+    }
+
+    /**
+     * Get the player that have received the money.
+     */
+    public Player getPlayer() {
+        return player;
+    }
+
+    /**
+     * Get the amount of money received.
+     */
+    public int getAmount() {
+        return amount;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+}

--- a/bedwars-api/src/main/java/com/andrei1058/bedwars/api/language/Messages.java
+++ b/bedwars-api/src/main/java/com/andrei1058/bedwars/api/language/Messages.java
@@ -272,6 +272,7 @@ public class Messages {
     public static String GAME_END_VICTORY_PLAYER_TITLE = "game-end-victory-title";
     public static String GAME_END_TOP_PLAYER_CHAT = "game-end-top-chat";
     public static String GAME_END_TEAM_WON_CHAT = "game-end-winner-team";
+    public static String GAME_END_PLAYER_REWARD_SUMMARY = "game-end-player-reward-summary";
     public static String XP_REWARD_WIN = "xp-reward-game-win";
     public static String XP_REWARD_PER_TEAMMATE = "xp-reward-per-teammate";
     public static String XP_REWARD_PER_MINUTE = "xp-reward-per-minute";

--- a/bedwars-api/src/main/java/com/andrei1058/bedwars/api/levels/Level.java
+++ b/bedwars-api/src/main/java/com/andrei1058/bedwars/api/levels/Level.java
@@ -50,6 +50,11 @@ public interface Level {
     String getProgressBar(Player p);
 
     /**
+     * @return current long progress bar.
+     */
+    String getLongProgressBar(Player p);
+
+    /**
      * @return current xp.
      */
     int getCurrentXp(Player p);

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/BedWars.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/BedWars.java
@@ -294,7 +294,7 @@ public class BedWars extends JavaPlugin {
             }, 1L);
 
         // Register events
-        registerEvents(new EnderPearlLanded(), new QuitAndTeleportListener(), new BreakPlace(), new DamageDeathMove(), new Inventory(), new Interact(), new RefreshGUI(), new HungerWeatherSpawn(), new CmdProcess(),
+        registerEvents(new RewardSummary(), new EnderPearlLanded(), new QuitAndTeleportListener(), new BreakPlace(), new DamageDeathMove(), new Inventory(), new Interact(), new RefreshGUI(), new HungerWeatherSpawn(), new CmdProcess(),
                 new FireballListener(), new EggBridge(), new SpectatorListeners(), new BaseListener(), new TargetListener(), new LangListener(), new Warnings(this), new ChatAFK());
         if (getServerType() == ServerType.BUNGEE) {
             if (autoscale) {

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/Arena.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/Arena.java
@@ -2679,18 +2679,18 @@ public class Arena implements IArena {
     }
 
     public int getCoinsEarned(UUID uuid){
-        return getCoinsEarned().get(uuid);
+        return coinsEarned.get(uuid);
     }
 
     public int getExperienceEarned(UUID uuid){
-        return getExperienceEarned().get(uuid);
+        return experienceEarned.get(uuid);
     }
 
-    public Map<UUID, Integer> getCoinsEarned(){
+    public Map<UUID, Integer> getCoinsMap(){
         return coinsEarned;
     }
 
-    public Map<UUID, Integer> getExperienceEarned(){
+    public Map<UUID, Integer> getExperienceMap(){
         return experienceEarned;
     }
 }

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/Arena.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/Arena.java
@@ -56,6 +56,7 @@ import com.andrei1058.bedwars.arena.tasks.ReJoinTask;
 import com.andrei1058.bedwars.arena.team.BedWarsTeam;
 import com.andrei1058.bedwars.arena.team.TeamAssigner;
 import com.andrei1058.bedwars.configuration.ArenaConfig;
+import com.andrei1058.bedwars.configuration.LevelsConfig;
 import com.andrei1058.bedwars.configuration.Sounds;
 import com.andrei1058.bedwars.levels.internal.InternalLevel;
 import com.andrei1058.bedwars.levels.internal.PerMinuteTask;
@@ -158,6 +159,9 @@ public class Arena implements IArena {
     private HashMap<Player, Integer> playerDeaths = new HashMap<>();
     private HashMap<Player, Integer> playerFinalKillDeaths = new HashMap<>();
 
+    /* SUMMARY REWARDS */
+    private final Map<UUID, Integer> coinsEarned = new HashMap<>();
+    private final Map<UUID, Integer> experienceEarned = new HashMap<>();
 
     /* ARENA TASKS */
     private StartingTask startingTask = null;
@@ -494,6 +498,8 @@ public class Arena implements IArena {
 
             p.closeInventory();
             players.add(p);
+            coinsEarned.put(p.getUniqueId(), 0);
+            experienceEarned.put(p.getUniqueId(), 0);
             p.setFlying(false);
             p.setAllowFlight(false);
             p.setHealth(20);
@@ -785,6 +791,8 @@ public class Arena implements IArena {
         //players.remove must be under call event in order to check if the player is a spectator or not
         players.remove(p);
         removeArenaByPlayer(p, this);
+        coinsEarned.remove(p.getUniqueId());
+        experienceEarned.remove(p.getUniqueId());
 
         for (PotionEffect pf : p.getActivePotionEffects()) {
             p.removePotionEffect(pf.getType());
@@ -1903,6 +1911,7 @@ public class Arena implements IArena {
                         if (!winner.getMembers().contains(p)) {
                             nms.sendTitle(p, getMsg(p, Messages.GAME_END_GAME_OVER_PLAYER_TITLE), null, 0, 70, 0);
                         }
+
                         for (String s : getList(p, Messages.GAME_END_TOP_PLAYER_CHAT)) {
                             String message = s.replace("{firstName}", firstName.isEmpty() ? getMsg(p, Messages.MEANING_NOBODY) : firstName).replace("{firstKills}", String.valueOf(first))
                                     .replace("{secondName}", secondName.isEmpty() ? getMsg(p, Messages.MEANING_NOBODY) : secondName).replace("{secondKills}", String.valueOf(second))
@@ -1911,6 +1920,22 @@ public class Arena implements IArena {
                                     .replace("{TeamColor}", winner.getColor().chat().toString()).replace("{TeamName}", winner.getDisplayName(Language.getPlayerLanguage(p)));
                             p.sendMessage(SupportPAPI.getSupportPAPI().replace(p, message));
                         }
+
+                        //Run task later cuz some coins are given too late and are not added to the map
+                        Bukkit.getScheduler().runTaskLater(plugin, () -> {
+                            for (String  s : getList(p, Messages.GAME_END_PLAYER_REWARD_SUMMARY)){
+                                String message = s
+                                        .replace("{coinsEarned}", String.valueOf(getCoinsEarned(p.getUniqueId())))
+                                        .replace("{experienceEarned}", String.valueOf(getExperienceEarned(p.getUniqueId())))
+                                        .replace("{percentAchieved}", String.valueOf(Math.round(BedWars.getLevelSupport().getCurrentXp(p) / (double) LevelsConfig.getNextCost(BedWars.getLevelSupport().getPlayerLevel(p)) * 100)))
+                                        .replace("{progress}", String.valueOf(BedWars.getLevelSupport().getLongProgressBar(p)))
+                                        .replace("{level}", String.valueOf(BedWars.getLevelSupport().getPlayerLevel(p)))
+                                        .replace("{nextLevel}", String.valueOf((BedWars.getLevelSupport().getPlayerLevel(p) + 1)))
+                                        .replace("{currentXp}", String.valueOf(BedWars.getLevelSupport().getCurrentXp(p)))
+                                        .replace("{requiredXp}", String.valueOf(BedWars.getLevelSupport().getRequiredXp(p)));
+                                p.sendMessage(SupportPAPI.getSupportPAPI().replace(p, message));
+                            }
+                        }, 11L);
                     }
                 }
                 changeStatus(GameState.restarting);
@@ -2651,5 +2676,21 @@ public class Arena implements IArena {
                 player.teleport(config.getConfigLoc("lobbyLoc"), PlayerTeleportEvent.TeleportCause.PLUGIN);
             }
         }
+    }
+
+    public int getCoinsEarned(UUID uuid){
+        return getCoinsEarned().get(uuid);
+    }
+
+    public int getExperienceEarned(UUID uuid){
+        return getExperienceEarned().get(uuid);
+    }
+
+    public Map<UUID, Integer> getCoinsEarned(){
+        return coinsEarned;
+    }
+
+    public Map<UUID, Integer> getExperienceEarned(){
+        return experienceEarned;
     }
 }

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/Bangla.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/Bangla.java
@@ -258,6 +258,20 @@ public class Bangla extends Language {
                 "&6                          &lDitio Killer &7- {secondName} - {secondKills}",
                 "&c                          &lTritio Killer &7- {thirdName} - {thirdKills}", "",
                 "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));
+        yml.addDefault(Messages.GAME_END_PLAYER_REWARD_SUMMARY, Arrays.asList("&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬",
+                "&r             &f&lReward Summary",
+                "&r ",
+                "  &7You earned",
+                "   &f&l• &6{coinsEarned} Bed Wars Coins",
+                "&r ",
+                "&r                 &bBed Wars Experience",
+                "&r      &bLevel {level}                             Level {nextLevel}",
+                "&r     {progress}",
+                "&r                 &b{currentXp} &7/ &a{requiredXp} &7({percentAchieved}%)",
+                "&r ",
+                "&7You earned &b{experienceEarned} Bed Wars Experience",
+                "&r ",
+                "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));
         yml.addDefault(Messages.BED_HOLOGRAM_DEFEND, "&c&lApnar Bichana rokkha korun!");
         yml.addDefault(Messages.BED_HOLOGRAM_DESTROYED, "&c&lApnar Bichana dhongso hoye giyeche!");
         yml.addDefault(Messages.NPC_NAME_TEAM_UPGRADES, "&bTEAM UPGRADES,&e&lRIGHT CLICK");

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/English.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/English.java
@@ -257,6 +257,20 @@ public class English extends Language {
                 "&6                          &l2nd Killer &7- {secondName} - {secondKills}",
                 "&c                          &l3rd Killer &7- {thirdName} - {thirdKills}", "",
                 "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));
+        yml.addDefault(Messages.GAME_END_PLAYER_REWARD_SUMMARY, Arrays.asList("&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬",
+                "&r             &f&lReward Summary",
+                "&r ",
+                "  &7You earned",
+                "   &f&l• &6{coinsEarned} Bed Wars Coins",
+                "&r ",
+                "&r                 &bBed Wars Experience",
+                "&r      &bLevel {level}                             Level {nextLevel}",
+                "&r     {progress}",
+                "&r                 &b{currentXp} &7/ &a{requiredXp} &7({percentAchieved}%)",
+                "&r ",
+                "&7You earned &b{experienceEarned} Bed Wars Experience",
+                "&r ",
+                "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));
         yml.addDefault(Messages.BED_HOLOGRAM_DEFEND, "&c&lDefend your bed!");
         yml.addDefault(Messages.BED_HOLOGRAM_DESTROYED, "&c&lYour bed was destroyed!");
         yml.addDefault(Messages.NPC_NAME_TEAM_UPGRADES, "&bTEAM UPGRADES,&e&lRIGHT CLICK");

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/Hindi.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/Hindi.java
@@ -257,6 +257,20 @@ public class Hindi extends Language {
                 "&6                          &lDusra Killer &7- {secondName} - {secondKills}",
                 "&c                          &lTeesra Killer &7- {thirdName} - {thirdKills}", "",
                 "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));
+        yml.addDefault(Messages.GAME_END_PLAYER_REWARD_SUMMARY, Arrays.asList("&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬",
+                "&r             &f&lReward Summary",
+                "&r ",
+                "  &7You earned",
+                "   &f&l• &6{coinsEarned} Bed Wars Coins",
+                "&r ",
+                "&r                 &bBed Wars Experience",
+                "&r      &bLevel {level}                             Level {nextLevel}",
+                "&r     {progress}",
+                "&r                 &b{currentXp} &7/ &a{requiredXp} &7({percentAchieved}%)",
+                "&r ",
+                "&7You earned &b{experienceEarned} Bed Wars Experience",
+                "&r ",
+                "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));
         yml.addDefault(Messages.BED_HOLOGRAM_DEFEND, "&c&lApke bistar ko rakhsha kare!");
         yml.addDefault(Messages.BED_HOLOGRAM_DESTROYED, "&c&lApka bistar tut gaya!");
         yml.addDefault(Messages.NPC_NAME_TEAM_UPGRADES, "&bTEAM UPGRADES,&e&lRIGHT CLICK");

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/Indonesia.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/Indonesia.java
@@ -257,6 +257,20 @@ public class Indonesia extends Language {
                 "&6                          &lPembunuh Kedua &7- {secondName} - {secondKills}",
                 "&c                          &lPembunuh Ketiga &7- {thirdName} - {thirdKills}", "",
                 "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));
+        yml.addDefault(Messages.GAME_END_PLAYER_REWARD_SUMMARY, Arrays.asList("&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬",
+                "&r             &f&lReward Summary",
+                "&r ",
+                "  &7You earned",
+                "   &f&l• &6{coinsEarned} Bed Wars Coins",
+                "&r ",
+                "&r                 &bBed Wars Experience",
+                "&r      &bLevel {level}                             Level {nextLevel}",
+                "&r     {progress}",
+                "&r                 &b{currentXp} &7/ &a{requiredXp} &7({percentAchieved}%)",
+                "&r ",
+                "&7You earned &b{experienceEarned} Bed Wars Experience",
+                "&r ",
+                "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));
         yml.addDefault(Messages.BED_HOLOGRAM_DEFEND, "&c&lPertahankan Kasur Anda!");
         yml.addDefault(Messages.BED_HOLOGRAM_DESTROYED, "&c&lKasur anda telah dihancurkan!");
         yml.addDefault(Messages.NPC_NAME_TEAM_UPGRADES, "&bPENINGKATAN TIM,&e&LKLIK KANAN");

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/Italian.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/Italian.java
@@ -255,6 +255,20 @@ public class Italian extends Language {
                 "&6                          &l2° Uccisore &7- {secondName} - {secondKills}",
                 "&c                          &l3° Uccisore &7- {thirdName} - {thirdKills}", "",
                 "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));
+        yml.addDefault(Messages.GAME_END_PLAYER_REWARD_SUMMARY, Arrays.asList("&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬",
+                "&r             &f&lReward Summary",
+                "&r ",
+                "  &7You earned",
+                "   &f&l• &6{coinsEarned} Bed Wars Coins",
+                "&r ",
+                "&r                 &bBed Wars Experience",
+                "&r      &bLevel {level}                             Level {nextLevel}",
+                "&r     {progress}",
+                "&r                 &b{currentXp} &7/ &a{requiredXp} &7({percentAchieved}%)",
+                "&r ",
+                "&7You earned &b{experienceEarned} Bed Wars Experience",
+                "&r ",
+                "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));
         yml.addDefault(Messages.GAME_END_TEAM_WON_CHAT, "{prefix}{TeamColor}{TeamName} &aha vinto il gioco!");
         yml.addDefault(Messages.BED_HOLOGRAM_DEFEND, "&c&lDifendi il tuo letto!");
         yml.addDefault(Messages.BED_HOLOGRAM_DESTROYED, "&c&lIl tuo letto è stato distrutto!");

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/Persian.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/Persian.java
@@ -258,6 +258,20 @@ public class Persian extends Language {
                 "&6                          &lMagham #2 &7- {secondName} - {secondKills}",
                 "&c                          &lMagham #3 &7- {thirdName} - {thirdKills}", "",
                 "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));
+        yml.addDefault(Messages.GAME_END_PLAYER_REWARD_SUMMARY, Arrays.asList("&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬",
+                "&r             &f&lReward Summary",
+                "&r ",
+                "  &7You earned",
+                "   &f&l• &6{coinsEarned} Bed Wars Coins",
+                "&r ",
+                "&r                 &bBed Wars Experience",
+                "&r      &bLevel {level}                             Level {nextLevel}",
+                "&r     {progress}",
+                "&r                 &b{currentXp} &7/ &a{requiredXp} &7({percentAchieved}%)",
+                "&r ",
+                "&7You earned &b{experienceEarned} Bed Wars Experience",
+                "&r ",
+                "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));
         yml.addDefault(Messages.BED_HOLOGRAM_DEFEND, "&c&lAz Bed khodetoon hefazat konid!");
         yml.addDefault(Messages.BED_HOLOGRAM_DESTROYED, "&c&lBed shoma az bein raft!");
         yml.addDefault(Messages.NPC_NAME_TEAM_UPGRADES, "&bUPGRADE HAYE TEAM,&e&lRIGHT CLICK");

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/Polish.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/Polish.java
@@ -255,6 +255,20 @@ public class Polish extends Language{
                 "&6                       &lTOP 2 Zabojca &7- {secondName} - {secondKills}",
                 "&c                       &lTOP 3 Zabojca &7- {thirdName} - {thirdKills}", "",
                 "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));
+        yml.addDefault(Messages.GAME_END_PLAYER_REWARD_SUMMARY, Arrays.asList("&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬",
+                "&r             &f&lReward Summary",
+                "&r ",
+                "  &7You earned",
+                "   &f&l• &6{coinsEarned} Bed Wars Coins",
+                "&r ",
+                "&r                 &bBed Wars Experience",
+                "&r      &bLevel {level}                             Level {nextLevel}",
+                "&r     {progress}",
+                "&r                 &b{currentXp} &7/ &a{requiredXp} &7({percentAchieved}%)",
+                "&r ",
+                "&7You earned &b{experienceEarned} Bed Wars Experience",
+                "&r ",
+                "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));
         yml.addDefault(Messages.GAME_END_TEAM_WON_CHAT, "{prefix}{TeamColor}{TeamName} &awygral gre!");
         yml.addDefault(Messages.NEXT_EVENT_BEDS_DESTROY, "&dZniszczenie lozek&f:");
         yml.addDefault(Messages.NEXT_EVENT_DIAMOND_UPGRADE_II, "&bDiament &cII&f:");

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/Portuguese.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/Portuguese.java
@@ -256,6 +256,20 @@ public class Portuguese extends Language {
                 "&6                          &l2º Assassino &7- {secondName} - {secondKills}",
                 "&c                          &l3º Assassino &7- {thirdName} - {thirdKills}", "",
                 "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));
+        yml.addDefault(Messages.GAME_END_PLAYER_REWARD_SUMMARY, Arrays.asList("&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬",
+                "&r             &f&lReward Summary",
+                "&r ",
+                "  &7You earned",
+                "   &f&l• &6{coinsEarned} Bed Wars Coins",
+                "&r ",
+                "&r                 &bBed Wars Experience",
+                "&r      &bLevel {level}                             Level {nextLevel}",
+                "&r     {progress}",
+                "&r                 &b{currentXp} &7/ &a{requiredXp} &7({percentAchieved}%)",
+                "&r ",
+                "&7You earned &b{experienceEarned} Bed Wars Experience",
+                "&r ",
+                "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));
         yml.addDefault(Messages.BED_HOLOGRAM_DEFEND, "&c&lDefenda sua cama!");
         yml.addDefault(Messages.BED_HOLOGRAM_DESTROYED, "&c&lSua cama foi destruída!");
         yml.addDefault(Messages.NPC_NAME_TEAM_UPGRADES, "&bMELHORIAS DA EQUIPE,&e&lCLIQUE DIREITO");

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/Romanian.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/Romanian.java
@@ -251,6 +251,20 @@ public class Romanian extends Language {
                 "&6                      &lAl 2-lea Ucigas &7- {secondName} - {secondKills}",
                 "&c                      &lAl 3-lea Ucigas &7- {thirdName} - {thirdKills}", "",
                 "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));
+        yml.addDefault(Messages.GAME_END_PLAYER_REWARD_SUMMARY, Arrays.asList("&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬",
+                "&r             &f&lReward Summary",
+                "&r ",
+                "  &7You earned",
+                "   &f&l• &6{coinsEarned} Bed Wars Coins",
+                "&r ",
+                "&r                 &bBed Wars Experience",
+                "&r      &bLevel {level}                             Level {nextLevel}",
+                "&r     {progress}",
+                "&r                 &b{currentXp} &7/ &a{requiredXp} &7({percentAchieved}%)",
+                "&r ",
+                "&7You earned &b{experienceEarned} Bed Wars Experience",
+                "&r ",
+                "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));
         yml.addDefault(Messages.GAME_END_TEAM_WON_CHAT, "{prefix}{TeamColor}Echipa {TeamName} &aa castigat!");
         yml.addDefault(Messages.NPC_NAME_TEAM_UPGRADES, "&bTEAM UPGRADES,&e&lCLICK DREAPTA");
         yml.addDefault(Messages.NPC_NAME_SOLO_UPGRADES, "&bSOLO UPGRADES,&e&lCLICK DREAPTA");

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/Russian.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/Russian.java
@@ -184,6 +184,20 @@ public class Russian extends Language{
                 "&6                          &l2-й Убийца &7- {secondName} - {secondKills}",
                 "&c                          &l3-й Убийца &7- {thirdName} - {thirdKills}", "",
                 "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));
+        yml.addDefault(Messages.GAME_END_PLAYER_REWARD_SUMMARY, Arrays.asList("&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬",
+                "&r             &f&lReward Summary",
+                "&r ",
+                "  &7You earned",
+                "   &f&l• &6{coinsEarned} Bed Wars Coins",
+                "&r ",
+                "&r                 &bBed Wars Experience",
+                "&r      &bLevel {level}                             Level {nextLevel}",
+                "&r     {progress}",
+                "&r                 &b{currentXp} &7/ &a{requiredXp} &7({percentAchieved}%)",
+                "&r ",
+                "&7You earned &b{experienceEarned} Bed Wars Experience",
+                "&r ",
+                "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));
         //yml.addDefault(gameOverReward, Arrays.asList("&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬",
         //        "&f                                   &lReward Summary", "", "",
         //        "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/Spanish.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/Spanish.java
@@ -187,6 +187,20 @@ public class Spanish extends Language{
                 "&6                         &l2do Asesino &7- {secondName} - {secondKills}",
                 "&c                         &l3er Asesino &7- {thirdName} - {thirdKills}", "",
                 "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));
+        yml.addDefault(Messages.GAME_END_PLAYER_REWARD_SUMMARY, Arrays.asList("&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬",
+                "&r             &f&lReward Summary",
+                "&r ",
+                "  &7You earned",
+                "   &f&l• &6{coinsEarned} Bed Wars Coins",
+                "&r ",
+                "&r                 &bBed Wars Experience",
+                "&r      &bLevel {level}                             Level {nextLevel}",
+                "&r     {progress}",
+                "&r                 &b{currentXp} &7/ &a{requiredXp} &7({percentAchieved}%)",
+                "&r ",
+                "&7You earned &b{experienceEarned} Bed Wars Experience",
+                "&r ",
+                "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));
         //yml.addDefault(gameOverReward, Arrays.asList("&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬",
         //        "&f                                   &lReward Summary", "", "",
         //        "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/Turkish.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/language/Turkish.java
@@ -258,6 +258,20 @@ public class Turkish extends Language {
                 "&6                          &l2. Oyuncu &7- {secondName} - {secondKills} öldürme",
                 "&c                          &l3. Oyuncu &7- {thirdName} - {thirdKills} öldürme", "",
                 "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));
+        yml.addDefault(Messages.GAME_END_PLAYER_REWARD_SUMMARY, Arrays.asList("&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬",
+                "&r             &f&lReward Summary",
+                "&r ",
+                "  &7You earned",
+                "   &f&l• &6{coinsEarned} Bed Wars Coins",
+                "&r ",
+                "&r                 &bBed Wars Experience",
+                "&r      &bLevel {level}                             Level {nextLevel}",
+                "&r     {progress}",
+                "&r                 &b{currentXp} &7/ &a{requiredXp} &7({percentAchieved}%)",
+                "&r ",
+                "&7You earned &b{experienceEarned} Bed Wars Experience",
+                "&r ",
+                "&a▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬"));
         yml.addDefault(Messages.BED_HOLOGRAM_DEFEND, "&c&lYatağını savun!");
         yml.addDefault(Messages.BED_HOLOGRAM_DESTROYED, "&c&lYatağın kırıldı!");
         yml.addDefault(Messages.NPC_NAME_TEAM_UPGRADES, "&bTAKIM YÜKSELTMELERİ,&e&lSAĞ TIKLA");

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/levels/internal/InternalLevel.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/levels/internal/InternalLevel.java
@@ -47,6 +47,11 @@ public class InternalLevel implements Level {
     }
 
     @Override
+    public String getLongProgressBar(Player p) {
+        return PlayerLevel.getLevelByPlayer(p.getUniqueId()).getLongProgressBar();
+    }
+
+    @Override
     public int getCurrentXp(Player p) {
         return PlayerLevel.getLevelByPlayer(p.getUniqueId()).getCurrentXp();
     }

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/levels/internal/PlayerLevel.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/levels/internal/PlayerLevel.java
@@ -27,7 +27,6 @@ import com.andrei1058.bedwars.configuration.LevelsConfig;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 
-import java.math.RoundingMode;
 import java.text.NumberFormat;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -35,20 +34,20 @@ import java.util.concurrent.ConcurrentHashMap;
 @SuppressWarnings("WeakerAccess")
 public class PlayerLevel {
 
-    private UUID uuid;
+    private final UUID uuid;
     private int level;
     private int nextLevelCost;
     private String levelName;
     private int currentXp;
     private String progressBar;
+    private String longProgressBar;
     private String requiredXp;
     private String formattedCurrentXp;
 
     // keep trace if current level is different than the one in database
     private boolean modified = false;
 
-    private static ConcurrentHashMap<UUID, PlayerLevel> levelByPlayer = new ConcurrentHashMap<>();
-
+    private static final ConcurrentHashMap<UUID, PlayerLevel> levelByPlayer = new ConcurrentHashMap<>();
 
     /**
      * Cache a player level.
@@ -65,6 +64,7 @@ public class PlayerLevel {
         this.level = level;
         this.currentXp = currentXp;
         updateProgressBar();
+        updateLongProgressBar();
         //requiredXp = nextLevelCost >= 1000 ? nextLevelCost % 1000 == 0 ? nextLevelCost / 1000 + "k" : (double) nextLevelCost / 1000 + "k" : String.valueOf(nextLevelCost);
         //formattedCurrentXp = currentXp >= 1000 ? currentXp % 1000 == 0 ? currentXp / 1000 + "k" : (double) currentXp / 1000 + "k" : String.valueOf(currentXp);
         if (!levelByPlayer.containsKey(player)) levelByPlayer.put(player, this);
@@ -89,6 +89,7 @@ public class PlayerLevel {
         this.level = level;
         this.currentXp = currentXp;
         updateProgressBar();
+        updateLongProgressBar();
 
         modified = false;
     }
@@ -109,6 +110,26 @@ public class PlayerLevel {
                         + LevelsConfig.levels.getString("progress-bar.locked-color") + String.valueOf(new char[locked]).replace("\0", LevelsConfig.levels.getString("progress-bar.symbol"))));
         requiredXp = formatNumber(nextLevelCost);
         formattedCurrentXp = formatNumber(currentXp);
+    }
+
+    /**
+     * Update the player long progress bar.
+     * This actually only change the amount of symbols.
+     * Could be improved or customized from level.yml
+     */
+    private void updateLongProgressBar() {
+        double l1 = ((nextLevelCost - currentXp) / (double) (nextLevelCost)) * 34;
+        int locked = (int) l1;
+        int unlocked = 34 - locked;
+        if (locked < 0 || unlocked < 0) {
+            locked = 34;
+            unlocked = 0;
+        }
+        longProgressBar = ChatColor.translateAlternateColorCodes('&', LevelsConfig.levels.getString("progress-bar.format").replace("{progress}",
+                LevelsConfig.levels.getString("progress-bar.unlocked-color") + String.valueOf(new char[unlocked]).replace("\0", LevelsConfig.levels.getString("progress-bar.symbol"))
+                        + LevelsConfig.levels.getString("progress-bar.locked-color") + String.valueOf(new char[locked]).replace("\0", LevelsConfig.levels.getString("progress-bar.symbol"))));
+        requiredXp = nextLevelCost >= 1000 ? nextLevelCost % 1000 == 0 ? nextLevelCost / 1000 + "k" : (double) nextLevelCost / 1000 + "k" : String.valueOf(nextLevelCost);
+        formattedCurrentXp = currentXp >= 1000 ? currentXp % 1000 == 0 ? currentXp / 1000 + "k" : (double) currentXp / 1000 + "k" : String.valueOf(currentXp);
     }
 
     /**
@@ -161,6 +182,13 @@ public class PlayerLevel {
     }
 
     /**
+     * Get progress long bar for player.
+     */
+    public String getLongProgressBar() {
+        return longProgressBar;
+    }
+
+    /**
      * Get target xp already formatted.
      * Like: 2000 is 2k
      */
@@ -176,6 +204,7 @@ public class PlayerLevel {
         this.currentXp += xp;
         upgradeLevel();
         updateProgressBar();
+        updateLongProgressBar();
         Bukkit.getPluginManager().callEvent(new PlayerXpGainEvent(Bukkit.getPlayer(uuid), xp, source));
         modified = true;
     }
@@ -200,6 +229,7 @@ public class PlayerLevel {
         this.levelName = ChatColor.translateAlternateColorCodes('&', LevelsConfig.getLevelName(level)).replace("{number}", String.valueOf(level));
         requiredXp = nextLevelCost >= 1000 ? nextLevelCost % 1000 == 0 ? nextLevelCost / 1000 + "k" : (double) nextLevelCost / 1000 + "k" : String.valueOf(nextLevelCost);
         updateProgressBar();
+        updateLongProgressBar();
         modified = true;
     }
 

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/RewardSummary.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/RewardSummary.java
@@ -14,8 +14,8 @@ public class RewardSummary implements Listener {
 
         IArena arena = Arena.getArenaByPlayer(e.getPlayer());
 
-        if (arena.getExperienceEarned().containsKey(e.getPlayer().getUniqueId())) {
-            arena.getExperienceEarned().put(e.getPlayer().getUniqueId(), arena.getExperienceEarned(e.getPlayer().getUniqueId()) + e.getAmount());
+        if (arena.getExperienceMap().containsKey(e.getPlayer().getUniqueId())) {
+            arena.getExperienceMap().put(e.getPlayer().getUniqueId(), arena.getExperienceEarned(e.getPlayer().getUniqueId()) + e.getAmount());
         }
     }
 
@@ -24,8 +24,8 @@ public class RewardSummary implements Listener {
 
         IArena arena = Arena.getArenaByPlayer(e.getPlayer());
 
-        if (arena.getCoinsEarned().containsKey(e.getPlayer().getUniqueId())) {
-            arena.getCoinsEarned().put(e.getPlayer().getUniqueId(), arena.getCoinsEarned(e.getPlayer().getUniqueId()) + e.getAmount());
+        if (arena.getCoinsMap().containsKey(e.getPlayer().getUniqueId())) {
+            arena.getCoinsMap().put(e.getPlayer().getUniqueId(), arena.getCoinsEarned(e.getPlayer().getUniqueId()) + e.getAmount());
         }
     }
 }

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/RewardSummary.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/RewardSummary.java
@@ -1,0 +1,31 @@
+package com.andrei1058.bedwars.listeners;
+
+import com.andrei1058.bedwars.api.arena.IArena;
+import com.andrei1058.bedwars.api.events.player.PlayerMoneyGainEvent;
+import com.andrei1058.bedwars.api.events.player.PlayerXpGainEvent;
+import com.andrei1058.bedwars.arena.Arena;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+public class RewardSummary implements Listener {
+
+    @EventHandler
+    public void onGainXp(PlayerXpGainEvent e){
+
+        IArena arena = Arena.getArenaByPlayer(e.getPlayer());
+
+        if (arena.getExperienceEarned().containsKey(e.getPlayer().getUniqueId())) {
+            arena.getExperienceEarned().put(e.getPlayer().getUniqueId(), arena.getExperienceEarned(e.getPlayer().getUniqueId()) + e.getAmount());
+        }
+    }
+
+    @EventHandler
+    public void onGainMoney(PlayerMoneyGainEvent e){
+
+        IArena arena = Arena.getArenaByPlayer(e.getPlayer());
+
+        if (arena.getCoinsEarned().containsKey(e.getPlayer().getUniqueId())) {
+            arena.getCoinsEarned().put(e.getPlayer().getUniqueId(), arena.getCoinsEarned(e.getPlayer().getUniqueId()) + e.getAmount());
+        }
+    }
+}

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/money/internal/MoneyListeners.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/money/internal/MoneyListeners.java
@@ -4,6 +4,7 @@ import com.andrei1058.bedwars.BedWars;
 import com.andrei1058.bedwars.api.events.gameplay.GameEndEvent;
 import com.andrei1058.bedwars.api.events.player.PlayerBedBreakEvent;
 import com.andrei1058.bedwars.api.events.player.PlayerKillEvent;
+import com.andrei1058.bedwars.api.events.player.PlayerMoneyGainEvent;
 import com.andrei1058.bedwars.api.language.Language;
 import com.andrei1058.bedwars.api.language.Messages;
 import com.andrei1058.bedwars.configuration.MoneyConfig;
@@ -21,22 +22,25 @@ public class MoneyListeners implements Listener {
      */
     @EventHandler
     public void onGameEnd(GameEndEvent e) {
-        for (UUID p : e.getWinners ()) {
-            Player player = Bukkit.getPlayer ( p );
+        for (UUID uuid : e.getWinners ()) {
+            Player player = Bukkit.getPlayer(uuid);
             if (player == null) continue;
-            int gamewin = MoneyConfig.money.getInt ( "money-rewards.game-win" );
-            if (gamewin > 0) {
-                BedWars.getEconomy ().giveMoney ( player, gamewin );
-                player.sendMessage ( Language.getMsg ( player, Messages.MONEY_REWARD_WIN ).replace ( "{money}", String.valueOf ( gamewin ) ) );
+            int moneyPerWin = MoneyConfig.money.getInt("money-rewards.game-win");
+            if (moneyPerWin > 0) {
+                BedWars.getEconomy().giveMoney(player, moneyPerWin);
+                player.sendMessage(Language.getMsg(player, Messages.MONEY_REWARD_WIN).replace("{money}", String.valueOf(moneyPerWin)));
+                Bukkit.getPluginManager().callEvent(new PlayerMoneyGainEvent(player, moneyPerWin));
             }
         }
-        for (UUID p : e.getLosers ()) {
-            Player player = Bukkit.getPlayer ( p );
+
+        for (UUID uuid : e.getLosers()) {
+            Player player = Bukkit.getPlayer(uuid);
             if (player == null) continue;
-            int teammate = MoneyConfig.money.getInt ( "money-rewards.per-teammate" );
-            if (teammate > 0) {
-                BedWars.getEconomy ().giveMoney ( player, teammate );
-                player.sendMessage ( Language.getMsg ( player, Messages.MONEY_REWARD_PER_TEAMMATE ).replace ( "{money}", String.valueOf ( teammate ) ) );
+            int moneyPerTeammate = MoneyConfig.money.getInt("money-rewards.per-teammate");
+            if (moneyPerTeammate > 0) {
+                BedWars.getEconomy().giveMoney(player, moneyPerTeammate);
+                player.sendMessage(Language.getMsg(player, Messages.MONEY_REWARD_PER_TEAMMATE).replace("{money}", String.valueOf(moneyPerTeammate)));
+                Bukkit.getPluginManager().callEvent(new PlayerMoneyGainEvent(player, moneyPerTeammate));
             }
         }
     }
@@ -46,12 +50,13 @@ public class MoneyListeners implements Listener {
      */
     @EventHandler
     public void onBreakBed(PlayerBedBreakEvent e) {
-        Player player = e.getPlayer ();
+        Player player = e.getPlayer();
         if (player == null) return;
-        int beddestroy = MoneyConfig.money.getInt ( "money-rewards.bed-destroyed" );
-        if (beddestroy > 0) {
-            BedWars.getEconomy ().giveMoney ( player, beddestroy );
-            player.sendMessage ( Language.getMsg ( player, Messages.MONEY_REWARD_BED_DESTROYED ).replace ( "{money}", String.valueOf ( beddestroy ) ) );
+        int moneyPerBedDestroy = MoneyConfig.money.getInt ("money-rewards.bed-destroyed");
+        if (moneyPerBedDestroy > 0) {
+            BedWars.getEconomy().giveMoney(player, moneyPerBedDestroy);
+            player.sendMessage(Language.getMsg(player, Messages.MONEY_REWARD_BED_DESTROYED).replace("{money}", String.valueOf(moneyPerBedDestroy)));
+            Bukkit.getPluginManager().callEvent(new PlayerMoneyGainEvent(player, moneyPerBedDestroy));
         }
     }
 
@@ -60,20 +65,22 @@ public class MoneyListeners implements Listener {
      */
     @EventHandler
     public void onKill(PlayerKillEvent e) {
-        Player player = e.getKiller ();
-        Player victim = e.getVictim ();
+        Player player = e.getKiller();
+        Player victim = e.getVictim();
         if (player == null || victim.equals(player)) return;
-        int finalkill = MoneyConfig.money.getInt ( "money-rewards.final-kill" );
-        int regularkill = MoneyConfig.money.getInt ( "money-rewards.regular-kill" );
-        if (e.getCause ().isFinalKill ()) {
-            if (finalkill > 0) {
-                BedWars.getEconomy ().giveMoney ( player, finalkill );
-                player.sendMessage ( Language.getMsg ( player, Messages.MONEY_REWARD_FINAL_KILL ).replace ( "{money}", String.valueOf ( finalkill ) ) );
+        int moneyPerFinalKill = MoneyConfig.money.getInt("money-rewards.final-kill");
+        int moneyPerRegularKill = MoneyConfig.money.getInt("money-rewards.regular-kill");
+        if (e.getCause().isFinalKill()) {
+            if (moneyPerFinalKill > 0) {
+                BedWars.getEconomy().giveMoney(player, moneyPerFinalKill);
+                player.sendMessage(Language.getMsg(player, Messages.MONEY_REWARD_FINAL_KILL).replace("{money}", String.valueOf(moneyPerFinalKill)));
+                Bukkit.getPluginManager().callEvent(new PlayerMoneyGainEvent(player, moneyPerFinalKill));
             }
         } else {
-            if (regularkill > 0) {
-                BedWars.getEconomy ().giveMoney ( player, regularkill );
-                player.sendMessage ( Language.getMsg ( player, Messages.MONEY_REWARD_REGULAR_KILL ).replace ( "{money}", String.valueOf ( regularkill ) ) );
+            if (moneyPerRegularKill > 0) {
+                BedWars.getEconomy().giveMoney(player, moneyPerRegularKill);
+                player.sendMessage(Language.getMsg(player, Messages.MONEY_REWARD_REGULAR_KILL).replace("{money}", String.valueOf(moneyPerRegularKill)));
+                Bukkit.getPluginManager().callEvent(new PlayerMoneyGainEvent(player, moneyPerRegularKill));
             }
         }
     }


### PR DESCRIPTION
This implements the reward summary system.
Closes #206 

- New maps for keep the current coins and experience earned until game end.
- These maps are loaded on player join and destroyed on player leave.
- These maps are updated on addXp method and MoneyListeners methods.
- The message is implemented below of top killers message.
- The radical implements of "long progress bar" is for use in chat. The shorter progress bar it looks very ugly in the rewards summary message. This could be improved or customized from level.yml in the future.

- [ ] Cleanup and improve code