### PR TITLE
Band-aid fix for ConcurrentModificationException on disable

### DIFF
--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/BedWars.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/BedWars.java
@@ -601,7 +601,7 @@ public class BedWars extends JavaPlugin {
         if (getServerType() == ServerType.BUNGEE) {
             ArenaSocket.disable();
         }
-        for (IArena a : Arena.getArenas()) {
+        for (IArena a : new LinkedList<>(Arena.getArenas())) {
             try {
                 a.disable();
             } catch (Exception ex) {


### PR DESCRIPTION
Band-aid fix for ConcurrentModificationException on disable

I suspect the actual issue is somewhere in the funky arena management bedwars currently uses, so this is just until I can finish removing that and replacing it with an actual arena manager

Fixes #457 