### PR TITLE
Closes #516 - Fix Light Gray in AutoCreation of team

### DIFF
--- a/bedwars-api/src/main/java/com/andrei1058/bedwars/api/arena/team/TeamColor.java
+++ b/bedwars-api/src/main/java/com/andrei1058/bedwars/api/arena/team/TeamColor.java
@@ -234,7 +234,7 @@ public enum TeamColor {
                 name = "Red";
                 break;
             case "LIGHT_GRAY_WOOL":
-                name = "lGray";
+                name = "Gray";
                 break;
             case "BLUE_WOOL":
                 name = "Blue";
@@ -252,7 +252,7 @@ public enum TeamColor {
                 name = "Yellow";
                 break;
             case "GRAY_WOOL":
-                name = "Gray";
+                name = "Dark_Gray";
                 break;
         }
         return name;

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/commands/bedwars/subcmds/sensitive/setup/AutoCreateTeams.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/commands/bedwars/subcmds/sensitive/setup/AutoCreateTeams.java
@@ -134,7 +134,7 @@ public class AutoCreateTeams extends SubCommand {
                     p.sendMessage("§6§lNEW TEAMS FOUND:");
                     for (String tf : found) {
                         String name = TeamColor.enName(tf);
-                        p.sendMessage("§f ▪ " + TeamColor.getChatColor(name) + name);
+                        p.sendMessage("§f ▪ " + TeamColor.getChatColor(name) + name.replace("_", " "));
                     }
                     p.spigot().sendMessage(Misc.msgHoverClick("§6 ▪ §7§lClick here to create found teams.", "§fClick to create found teams!", "/" + getParent().getName() + " " + getSubCommandName(), ClickEvent.Action.RUN_COMMAND));
                 }


### PR DESCRIPTION
### Identify the Bug
Fixes #516 

### Description of the Change
Fix of exception regarding Light Gray in AutoCreation of team

### Alternate Designs
None

### Possible Drawbacks
Can't see any. Usage of method is limited to just the AutoCreate command.

### Verification Process
Tested the AutoCreation again, and both Gray and Dark Gray showed up.

### Release Notes
Fix of exception regarding Light Gray in AutoCreation of team