### PR TITLE
Fix Red not auto-scanning

### DIFF
--- a/bedwars-api/src/main/java/com/andrei1058/bedwars/api/arena/team/TeamColor.java
+++ b/bedwars-api/src/main/java/com/andrei1058/bedwars/api/arena/team/TeamColor.java
@@ -230,7 +230,7 @@ public enum TeamColor {
             case "PINK_WOOL":
                 name = "Pink";
                 break;
-            case "RED":
+            case "RED_WOOL":
                 name = "Red";
                 break;
             case "LIGHT_GRAY_WOOL":


### PR DESCRIPTION
### Identify the Bug

Fixes #517  

### Description of the Change
Fix of Red never showing up in AutoCreation of team

### Alternate Designs
None

### Possible Drawbacks
Can't see any. 

### Verification Process
Tested the AutoCreation again, and Red now shows up

### Release Notes
Fix of Red never showing up in AutoCreation of team