### PR TITLE
Cancel Pickup if player is AFK and remove extra listener

### DIFF
--- a/versionsupport_common/src/main/java/com/andrei1058/bedwars/listeners/ItemDropPickListener.java
+++ b/versionsupport_common/src/main/java/com/andrei1058/bedwars/listeners/ItemDropPickListener.java
@@ -87,17 +87,6 @@ public class ItemDropPickListener {
         }
     }
 
-    // common
-    public static class GeneratorCollect implements Listener {
-        @EventHandler
-        //Prevent AFK players from picking items
-        public void onCollect(PlayerGeneratorCollectEvent e){
-            if (api.getAFKUtil().isPlayerAFK(e.getPlayer())){
-                e.setCancelled(true);
-            }
-        }
-    }
-
     /**
      * @return true if event should be cancelled
      */
@@ -144,7 +133,7 @@ public class ItemDropPickListener {
                         } else {
                             item.getItemStack().setItemMeta(itemMeta);
                         }
-                    }
+                    }else return true; //Cancel event if player is afk
                 }
             }
         }

--- a/versionsupport_common/src/main/java/com/andrei1058/bedwars/listeners/PlayerDropPick_1_11Minus.java
+++ b/versionsupport_common/src/main/java/com/andrei1058/bedwars/listeners/PlayerDropPick_1_11Minus.java
@@ -101,6 +101,9 @@ public class PlayerDropPick_1_11Minus implements Listener {
                             e.getItem().getItemStack().setItemMeta(itemMeta);
                         }
                     }
+                    else {  //Cancel Event if play is afk
+                        e.setCancelled(true);
+                    }
                 }
             }
         }

--- a/versionsupport_common/src/main/java/com/andrei1058/bedwars/support/version/common/VersionCommon.java
+++ b/versionsupport_common/src/main/java/com/andrei1058/bedwars/support/version/common/VersionCommon.java
@@ -65,7 +65,7 @@ public class VersionCommon {
             //}
 
             // common
-            registerListeners(versionSupport.getPlugin(), new ItemDropPickListener.GeneratorCollect(), new ShopItemRestoreListener.DefaultRestoreInvClose());
+            registerListeners(versionSupport.getPlugin(), new ShopItemRestoreListener.DefaultRestoreInvClose());
     }
 
     private void registerListeners(Plugin plugin, Listener... listener) {


### PR DESCRIPTION
This is a continuation of #584 
Making players not pickup items when afk