### PR TITLE
Fixes issues with invsibility potion and armor & bug with inv. shop when click on bottom inv

### DIFF
--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/BedWars.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/BedWars.java
@@ -325,6 +325,7 @@ public class BedWars extends JavaPlugin {
         // Register setup-holograms fix
         registerEvents(new ChunkLoad());
 
+        registerEvents(new InvisibilityPotionListener());
 
         /* Deprecated versions */
         switch (version) {
@@ -337,7 +338,6 @@ public class BedWars extends JavaPlugin {
             case "v1_15_R1":
             case "v1_16_R1":
             case "v1_16_R2":
-                registerEvents(new InvisibilityPotionListener());
                 Bukkit.getScheduler().runTaskLater(this,
                         () -> System.out.println("\u001B[31m[WARN] BedWars1058 may drop support for this server version in the future.\nSee: https://wiki.andrei1058.dev/docs/BedWars1058/compatibility \u001B[0m"), 40L);
                 break;


### PR DESCRIPTION
- The problem was **InvisibilityPotionListener** was not being registered in some versions (1.8 and 1.12)
Fixes 
#586 
#573 
#522 

- The inv issue fixes 
#575 
#490 

The PR of #521 not working, makes unable to player move items from his inventory outside the shop.

The fixes have been tested.