### PR TITLE
Added placeholders {team} and {teamColor} to display the player team and its corresponding colors on the teleporter

### DIFF
--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/spectator/TeleporterGUI.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/spectator/TeleporterGUI.java
@@ -78,7 +78,7 @@ public class TeleporterGUI {
         if (arena == null) return;
 
         int playersNum = arena.getPlayers().size();
-        int size = (playersNum % 9) == 0 ? playersNum / 9 : ((int) Math.ceil(playersNum / 9.0)) * 9;
+        int size = (playersNum % 9) == 0 ? playersNum : ((int) Math.ceil(playersNum / 9.0)) * 9;
 
         Inventory inv = Bukkit.createInventory(p, size, getMsg(p, Messages.ARENA_SPECTATOR_TELEPORTER_GUI_NAME));
         refreshInv(p, inv);

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/spectator/TeleporterGUI.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/spectator/TeleporterGUI.java
@@ -77,8 +77,12 @@ public class TeleporterGUI {
         IArena arena = Arena.getArenaByPlayer(p);
         if (arena == null) return;
 
-        int playersNum = arena.getPlayers().size();
-        int size = (playersNum % 9) == 0 ? playersNum : ((int) Math.ceil(playersNum / 9.0)) * 9;
+        int playerCount = arena.getPlayers().size();
+        int size = (playerCount % 9) == 0 ? playerCount : ((int) Math.ceil(playerCount / 9.0)) * 9;
+
+        if (size > 54) {
+            size = 54;
+        }
 
         Inventory inv = Bukkit.createInventory(p, size, getMsg(p, Messages.ARENA_SPECTATOR_TELEPORTER_GUI_NAME));
         refreshInv(p, inv);

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/spectator/TeleporterGUI.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/spectator/TeleporterGUI.java
@@ -22,6 +22,8 @@ package com.andrei1058.bedwars.arena.spectator;
 
 import com.andrei1058.bedwars.BedWars;
 import com.andrei1058.bedwars.api.arena.IArena;
+import com.andrei1058.bedwars.api.arena.team.ITeam;
+import com.andrei1058.bedwars.api.language.Language;
 import com.andrei1058.bedwars.api.language.Messages;
 import com.andrei1058.bedwars.arena.Arena;
 import org.bukkit.Bukkit;
@@ -74,20 +76,10 @@ public class TeleporterGUI {
     public static void openGUI(Player p) {
         IArena arena = Arena.getArenaByPlayer(p);
         if (arena == null) return;
-        int size = arena.getPlayers().size();
-        if (size <= 9) {
-            size = 9;
-        } else if (size <= 18) {
-            size = 18;
-        } else if (size > 19 && size <= 27) {
-            size = 27;
-        } else if (size > 27 && size <= 36) {
-            size = 36;
-        } else if (size > 36 && size <= 45) {
-            size = 45;
-        } else {
-            size = 54;
-        }
+
+        int playersNum = arena.getPlayers().size();
+        int size = (playersNum % 9) == 0 ? playersNum / 9 : ((int) Math.ceil(playersNum / 9.0)) * 9;
+
         Inventory inv = Bukkit.createInventory(p, size, getMsg(p, Messages.ARENA_SPECTATOR_TELEPORTER_GUI_NAME));
         refreshInv(p, inv);
         refresh.put(p, inv);
@@ -117,9 +109,14 @@ public class TeleporterGUI {
         ItemStack i = nms.getPlayerHead(targetPlayer, null);
         ItemMeta im = i.getItemMeta();
         assert im != null;
+        IArena currentArena = Arena.getArenaByPlayer(targetPlayer);
+        ITeam targetPlayerTeam = currentArena.getTeam(targetPlayer);
+
         im.setDisplayName(getMsg(GUIholder, Messages.ARENA_SPECTATOR_TELEPORTER_GUI_HEAD_NAME)
                 .replace("{vPrefix}", BedWars.getChatSupport().getPrefix(targetPlayer))
                 .replace("{vSuffix}", BedWars.getChatSupport().getSuffix(targetPlayer))
+                .replace("{team}", targetPlayerTeam.getDisplayName(Language.getPlayerLanguage(GUIholder)))
+                .replace("{teamColor}", String.valueOf(targetPlayerTeam.getColor().chat()))
                 .replace("{player}", targetPlayer.getDisplayName())
                 .replace("{playername}", targetPlayer.getName()));
         List<String> lore = new ArrayList<>();


### PR DESCRIPTION
Added placeholders {team} and {teamColor} to display the player team and its corresponding colors on the teleporter, using it in the inspector tp gui head name in the language file, like this

spectator-tp-gui-head-name: '{teamColor}{team} {vPrefix}{player}'

#766 
#605 