### PR TITLE
Apply generator protection radius for normal blocks

### DIFF
--- a/bedwars-api/src/main/java/com/andrei1058/bedwars/api/arena/generator/IGenerator.java
+++ b/bedwars-api/src/main/java/com/andrei1058/bedwars/api/arena/generator/IGenerator.java
@@ -22,6 +22,7 @@ package com.andrei1058.bedwars.api.arena.generator;
 
 import com.andrei1058.bedwars.api.arena.IArena;
 import com.andrei1058.bedwars.api.arena.team.ITeam;
+import com.andrei1058.bedwars.api.region.Region;
 import org.bukkit.Location;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Player;
@@ -88,6 +89,11 @@ public interface IGenerator {
      * Get the generator location.
      */
     Location getLocation();
+    
+    /**
+     * Get generator region
+     */
+    Region getRegion();
 
     /**
      * Get generator ore.

--- a/bedwars-api/src/main/java/com/andrei1058/bedwars/api/configuration/ConfigPath.java
+++ b/bedwars-api/src/main/java/com/andrei1058/bedwars/api/configuration/ConfigPath.java
@@ -166,7 +166,9 @@ public class ConfigPath {
     public static final String ARENA_SPAWN_PROTECTION = "spawn-protection";
     public static final String ARENA_SHOP_PROTECTION = "shop-protection";
     public static final String ARENA_UPGRADES_PROTECTION = "upgrades-protection";
-    public static final String ARENA_GENERATOR_PROTECTION = "generator-protection";
+    public static final String ARENA_GENERATOR_PROTECTION_RADIUS = "generator-protection-radius";
+    public static final String ARENA_GENERATOR_PROTECTION_MAX_Y = "generator-protection-max-y";
+    public static final String ARENA_GENERATOR_PROTECTION_MIN_Y = "generator-protection-min-y";
     public static final String ARENA_DISABLE_GENERATOR_FOR_EMPTY_TEAMS = "disable-generator-for-empty-teams";
     public static final String ARENA_DISABLE_NPCS_FOR_EMPTY_TEAMS = "disable-npcs-for-empty-teams";
     public static final String ARENA_ISLAND_RADIUS = "island-radius";

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/Misc.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/Misc.java
@@ -389,18 +389,6 @@ public class Misc {
                 return true;
             }
         }
-        for (ITeam t : a.getTeams()) {
-            for (IGenerator o : t.getGenerators()) {
-                if (o.getLocation().distance(l) <= 1) {
-                    return true;
-                }
-            }
-        }
-        for (IGenerator o : a.getOreGenerators()) {
-            if (o.getLocation().distance(l) <= 1) {
-                return true;
-            }
-        }
         return isOutsideOfBorder(l);
     }
 

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/OreGenerator.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/OreGenerator.java
@@ -82,7 +82,7 @@ public class OreGenerator implements IGenerator {
         loadDefaults();
         BedWars.debug("Initializing new generator at: " + location + " - " + type + " - " + (bwt == null ? "NOTEAM" : bwt.getName()));
 
-        Cuboid c = new Cuboid(location, 1, true);
+        Cuboid c = new Cuboid(location, arena.getConfig().getInt(ConfigPath.ARENA_GENERATOR_PROTECTION), true);
         c.setMaxY(c.getMaxY() + 5);
         c.setMinY(c.getMinY() - 2);
         arena.getRegionsList().add(c);

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/OreGenerator.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/OreGenerator.java
@@ -32,6 +32,7 @@ import com.andrei1058.bedwars.api.events.gameplay.GeneratorUpgradeEvent;
 import com.andrei1058.bedwars.api.language.Language;
 import com.andrei1058.bedwars.api.language.Messages;
 import com.andrei1058.bedwars.api.region.Cuboid;
+import com.andrei1058.bedwars.api.region.Region;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -58,6 +59,7 @@ public class OreGenerator implements IGenerator {
     private GeneratorType type;
     private int rotate = 0, dropID = 0;
     private ITeam bwt;
+    private Region region;
     boolean up = true;
 
     /**
@@ -82,10 +84,11 @@ public class OreGenerator implements IGenerator {
         loadDefaults();
         BedWars.debug("Initializing new generator at: " + location + " - " + type + " - " + (bwt == null ? "NOTEAM" : bwt.getName()));
 
-        Cuboid c = new Cuboid(location, arena.getConfig().getInt(ConfigPath.ARENA_GENERATOR_PROTECTION), true);
-        c.setMaxY(c.getMaxY() + 5);
-        c.setMinY(c.getMinY() - 2);
+        Cuboid c = new Cuboid(location, arena.getConfig().getInt(ConfigPath.ARENA_GENERATOR_PROTECTION_RADIUS), true);
+        c.setMaxY(location.getBlockY() + arena.getConfig().getInt(ConfigPath.ARENA_GENERATOR_PROTECTION_MAX_Y));
+        c.setMinY(location.getBlockY() - arena.getConfig().getInt(ConfigPath.ARENA_GENERATOR_PROTECTION_MIN_Y));
         arena.getRegionsList().add(c);
+        this.region = c;
     }
 
     @Override
@@ -369,6 +372,11 @@ public class OreGenerator implements IGenerator {
     @Override
     public Location getLocation() {
         return location;
+    }
+
+    @Override
+    public Region getRegion() {
+        return region;
     }
 
     @Override

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/configuration/ArenaConfig.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/configuration/ArenaConfig.java
@@ -43,7 +43,9 @@ public class ArenaConfig extends ConfigManager {
         yml.addDefault(ConfigPath.ARENA_SPAWN_PROTECTION, 5);
         yml.addDefault(ConfigPath.ARENA_SHOP_PROTECTION, 1);
         yml.addDefault(ConfigPath.ARENA_UPGRADES_PROTECTION, 1);
-        yml.addDefault(ConfigPath.ARENA_GENERATOR_PROTECTION, 1);
+        yml.addDefault(ConfigPath.ARENA_GENERATOR_PROTECTION_RADIUS, 1);
+        yml.addDefault(ConfigPath.ARENA_GENERATOR_PROTECTION_MAX_Y, 5);
+        yml.addDefault(ConfigPath.ARENA_GENERATOR_PROTECTION_MIN_Y, 2);
         yml.addDefault(ConfigPath.ARENA_ISLAND_RADIUS, 17);
         yml.addDefault("worldBorder", 300);
         yml.addDefault(ConfigPath.ARENA_Y_LEVEL_KILL, -1);

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/BreakPlace.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/BreakPlace.java
@@ -507,7 +507,7 @@ public class BreakPlace implements Listener {
                         return;
                     }
                     for (IGenerator o : t.getGenerators()) {
-                        if (o.getLocation().distance(e.getBlockClicked().getLocation()) <= a.getConfig().getInt(ConfigPath.ARENA_GENERATOR_PROTECTION)) {
+                        if (o.getRegion().isInRegion(e.getBlockClicked().getLocation())) {
                             e.setCancelled(true);
                             p.sendMessage(getMsg(p, Messages.INTERACT_CANNOT_PLACE_BLOCK));
                             return;
@@ -515,7 +515,7 @@ public class BreakPlace implements Listener {
                     }
                 }
                 for (IGenerator o : a.getOreGenerators()) {
-                    if (o.getLocation().distance(e.getBlockClicked().getLocation()) <= a.getConfig().getInt(ConfigPath.ARENA_GENERATOR_PROTECTION)) {
+                    if (o.getRegion().isInRegion(e.getBlockClicked().getLocation())) {
                         e.setCancelled(true);
                         p.sendMessage(getMsg(p, Messages.INTERACT_CANNOT_PLACE_BLOCK));
                         return;


### PR DESCRIPTION
in PR #412 the author failed to apply the generator protection to the region defined by ore generators for build protection thus effectively rendering the option useless. 