### PR TITLE
Fix magic miner upgrade

### DIFF
--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/configuration/UpgradesConfig.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/configuration/UpgradesConfig.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static com.andrei1058.bedwars.BedWars.getForCurrentVersion;
 import static com.andrei1058.bedwars.BedWars.plugin;
 
 public class UpgradesConfig extends ConfigManager {
@@ -73,13 +74,12 @@ public class UpgradesConfig extends ConfigManager {
 
             yml.addDefault("upgrade-miner.tier-1.currency", "diamond");
             yml.addDefault("upgrade-miner.tier-1.cost", 2);
-            addDefaultDisplayItem("upgrade-miner.tier-1", "GOLD_PICKAXE", 0, 1, false);
+            addDefaultDisplayItem("upgrade-miner.tier-1", getForCurrentVersion("GOLD_PICKAXE", "GOLD_PICKAXE", "GOLDEN_PICKAXE"), 0, 1, false)
             yml.addDefault("upgrade-miner.tier-1.receive", Collections.singletonList("player-effect: FAST_DIGGING,0,0,team"));
 
             yml.addDefault("upgrade-miner.tier-2.currency", "diamond");
             yml.addDefault("upgrade-miner.tier-2.cost", 4);
-            addDefaultDisplayItem("upgrade-miner.tier-2", "GOLD_PICKAXE", 0, 2, false);
-            yml.addDefault("upgrade-miner.tier-2.receive", Collections.singletonList("player-effect: FAST_DIGGING,1,0,team"));
+            addDefaultDisplayItem("upgrade-miner.tier-2", getForCurrentVersion("GOLD_PICKAXE", "GOLD_PICKAXE", "GOLDEN_PICKAXE"), 0, 2, false);            yml.addDefault("upgrade-miner.tier-2.receive", Collections.singletonList("player-effect: FAST_DIGGING,1,0,team"));
 
             yml.addDefault("upgrade-forge.tier-1.currency", "diamond");
             yml.addDefault("upgrade-forge.tier-1.cost", 2);
@@ -118,17 +118,17 @@ public class UpgradesConfig extends ConfigManager {
                     "base-trap-3,12", "base-trap-4,13", "separator-back,31"));
 
             yml.addDefault("separator-glass.on-click", "");
-            addDefaultDisplayItem("separator-glass", BedWars.getForCurrentVersion("STAINED_GLASS_PANE", "STAINED_GLASS_PANE",
+            addDefaultDisplayItem("separator-glass", getForCurrentVersion("STAINED_GLASS_PANE", "STAINED_GLASS_PANE",
                     "GRAY_STAINED_GLASS_PANE"), 7, 1, false);
 
             yml.addDefault("trap-slot-first.trap", 1);
-            addDefaultDisplayItem("trap-slot-first", BedWars.getForCurrentVersion("STAINED_GLASS", "STAINED_GLASS",
+            addDefaultDisplayItem("trap-slot-first", getForCurrentVersion("STAINED_GLASS", "STAINED_GLASS",
                     "GRAY_STAINED_GLASS"), 8, 1, false);
             yml.addDefault("trap-slot-second.trap", 2);
-            addDefaultDisplayItem("trap-slot-second", BedWars.getForCurrentVersion("STAINED_GLASS", "STAINED_GLASS",
+            addDefaultDisplayItem("trap-slot-second", getForCurrentVersion("STAINED_GLASS", "STAINED_GLASS",
                     "GRAY_STAINED_GLASS"), 8, 2, false);
             yml.addDefault("trap-slot-third.trap", 3);
-            addDefaultDisplayItem("trap-slot-third", BedWars.getForCurrentVersion("STAINED_GLASS", "STAINED_GLASS",
+            addDefaultDisplayItem("trap-slot-third", getForCurrentVersion("STAINED_GLASS", "STAINED_GLASS",
                     "GRAY_STAINED_GLASS"), 8, 3, false);
 
             addDefaultDisplayItem("base-trap-1", "TRIPWIRE_HOOK", 0, 1, false);
@@ -137,7 +137,7 @@ public class UpgradesConfig extends ConfigManager {
             addDefaultDisplayItem("base-trap-2", "FEATHER", 0, 1, false);
             yml.addDefault("base-trap-2.receive", Collections.singletonList("player-effect: SPEED,1,15,base"));
 
-            addDefaultDisplayItem("base-trap-3", BedWars.getForCurrentVersion("REDSTONE_TORCH_ON", "REDSTONE_TORCH", "REDSTONE_TORCH"), 0, 1, false);
+            addDefaultDisplayItem("base-trap-3", getForCurrentVersion("REDSTONE_TORCH_ON", "REDSTONE_TORCH", "REDSTONE_TORCH"), 0, 1, false);
             yml.addDefault("base-trap-3.custom-announce", true);
             yml.addDefault("base-trap-3.receive", Collections.singletonList("remove-effect: INVISIBILITY,enemy"));
 

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/configuration/UpgradesConfig.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/configuration/UpgradesConfig.java
@@ -74,7 +74,7 @@ public class UpgradesConfig extends ConfigManager {
 
             yml.addDefault("upgrade-miner.tier-1.currency", "diamond");
             yml.addDefault("upgrade-miner.tier-1.cost", 2);
-            addDefaultDisplayItem("upgrade-miner.tier-1", getForCurrentVersion("GOLD_PICKAXE", "GOLD_PICKAXE", "GOLDEN_PICKAXE"), 0, 1, false)
+            addDefaultDisplayItem("upgrade-miner.tier-1", getForCurrentVersion("GOLD_PICKAXE", "GOLD_PICKAXE", "GOLDEN_PICKAXE"), 0, 1, false);
             yml.addDefault("upgrade-miner.tier-1.receive", Collections.singletonList("player-effect: FAST_DIGGING,0,0,team"));
 
             yml.addDefault("upgrade-miner.tier-2.currency", "diamond");


### PR DESCRIPTION
Fixed bug where magic miner upgrade was showing wrong material name in version 1.13 and above.