### PR TITLE
change heal pool work

### DIFF
--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/upgrades/HealPoolListner.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/upgrades/HealPoolListner.java
@@ -13,7 +13,7 @@ import org.bukkit.event.Listener;
 public class HealPoolListner implements Listener {
     @EventHandler
     public void onTeamUpgrade(UpgradeBuyEvent e){
-        if (e.getTeamUpgrade().getName().equalsIgnoreCase("upgrade-heal-pool")){
+        if (e.getTeamUpgrade().getName().contains("heal-pool")){
             IArena a = e.getArena();
             if (a == null) return;
             ITeam bwt = a.getTeam(e.getPlayer());

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/commands/bedwars/subcmds/regular/CmdStart.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/commands/bedwars/subcmds/regular/CmdStart.java
@@ -25,6 +25,7 @@ import com.andrei1058.bedwars.api.arena.GameState;
 import com.andrei1058.bedwars.api.arena.IArena;
 import com.andrei1058.bedwars.api.command.ParentCommand;
 import com.andrei1058.bedwars.api.command.SubCommand;
+import com.andrei1058.bedwars.api.configuration.ConfigPath;
 import com.andrei1058.bedwars.api.language.Messages;
 import com.andrei1058.bedwars.arena.Arena;
 import com.andrei1058.bedwars.arena.SetupSession;
@@ -75,8 +76,8 @@ public class CmdStart extends SubCommand {
                 return true;
             }
         }
-        if (a.getStartingTask().getCountdown() < 5) return true;
-        a.getStartingTask().setCountdown(5);
+        if (a.getStartingTask().getCountdown() < BedWars.config.getInt(ConfigPath.GENERAL_CONFIGURATION_START_COUNTDOWN_SHORTENED)) return true;
+        a.getStartingTask().setCountdown(BedWars.config.getInt(ConfigPath.GENERAL_CONFIGURATION_START_COUNTDOWN_SHORTENED));
         p.sendMessage(getMsg(p, Messages.COMMAND_FORCESTART_SUCCESS));
         return true;
     }

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/commands/bedwars/subcmds/regular/CmdStart.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/commands/bedwars/subcmds/regular/CmdStart.java
@@ -76,8 +76,8 @@ public class CmdStart extends SubCommand {
                 return true;
             }
         }
-        if (a.getStartingTask().getCountdown() < BedWars.config.getInt(ConfigPath.GENERAL_CONFIGURATION_START_COUNTDOWN_SHORTENED)) return true;
-        a.getStartingTask().setCountdown(BedWars.config.getInt(ConfigPath.GENERAL_CONFIGURATION_START_COUNTDOWN_SHORTENED));
+        if (a.getStartingTask().getCountdown() < 5) return true;
+        a.getStartingTask().setCountdown(5);
         p.sendMessage(getMsg(p, Messages.COMMAND_FORCESTART_SUCCESS));
         return true;
     }


### PR DESCRIPTION
Since the upgrade price is likely to be different for each arena group, if the upgrade has a heal-pool in the name, it is changed to work