### PR TITLE
Add an option to stop setting header and footer

### DIFF
--- a/bedwars-api/src/main/java/com/andrei1058/bedwars/api/configuration/ConfigPath.java
+++ b/bedwars-api/src/main/java/com/andrei1058/bedwars/api/configuration/ConfigPath.java
@@ -130,6 +130,7 @@ public class ConfigPath {
     public static final String SB_CONFIG_SIDEBAR_USE_GAME_SIDEBAR = "scoreboard-settings.sidebar.enable-game-sidebar";
     public static final String SB_CONFIG_SIDEBAR_TITLE_REFRESH_INTERVAL = "scoreboard-settings.sidebar.title-refresh-interval";
     public static final String SB_CONFIG_SIDEBAR_PLACEHOLDERS_REFRESH_INTERVAL = "scoreboard-settings.sidebar.placeholders-refresh-interval";
+    public static final String SB_CONFIG_SIDEBAR_LIST_SET_HEADER_FOOTER = "scoreboard-settings.player-list.set-header-footer";
     public static final String SB_CONFIG_SIDEBAR_LIST_FORMAT_LOBBY = "scoreboard-settings.player-list.format-lobby-list";
     public static final String SB_CONFIG_SIDEBAR_LIST_FORMAT_WAITING = "scoreboard-settings.player-list.format-waiting-list";
     public static final String SB_CONFIG_SIDEBAR_LIST_FORMAT_STARTING = "scoreboard-settings.player-list.format-starting-list";

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/BedWars.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/BedWars.java
@@ -112,7 +112,7 @@ public class BedWars extends JavaPlugin {
 
     private static ServerType serverType = ServerType.MULTIARENA;
     public static boolean debug = true, autoscale = false;
-    public static String mainCmd = "bw", link = "https://www.spigotmc.org/resources/50942/";
+    public static String mainCmd = "bw", link = "https://www.spigotmc.org/resources/97320/";
     public static ConfigManager signs, generators;
     public static MainConfig config;
     public static ShopManager shop;

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/configuration/MainConfig.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/configuration/MainConfig.java
@@ -65,6 +65,7 @@ public class MainConfig extends ConfigManager {
         yml.addDefault(ConfigPath.SB_CONFIG_SIDEBAR_USE_GAME_SIDEBAR, true);
         yml.addDefault(ConfigPath.SB_CONFIG_SIDEBAR_TITLE_REFRESH_INTERVAL, 4);
         yml.addDefault(ConfigPath.SB_CONFIG_SIDEBAR_PLACEHOLDERS_REFRESH_INTERVAL, 20);
+        yml.addDefault(ConfigPath.SB_CONFIG_SIDEBAR_LIST_SET_HEADER_FOOTER, true);
         yml.addDefault(ConfigPath.SB_CONFIG_SIDEBAR_LIST_FORMAT_LOBBY, false);
         yml.addDefault(ConfigPath.SB_CONFIG_SIDEBAR_LIST_FORMAT_WAITING, false);
         yml.addDefault(ConfigPath.SB_CONFIG_SIDEBAR_LIST_FORMAT_STARTING, false);

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/sidebar/BwSidebar.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/sidebar/BwSidebar.java
@@ -90,7 +90,10 @@ public class BwSidebar implements ISidebar {
             }, 2L);
         }
         handlePlayerList();
-        setHeaderFooter();
+
+        if (config.getBoolean(ConfigPath.SB_CONFIG_SIDEBAR_LIST_SET_HEADER_FOOTER)) {
+            setHeaderFooter();
+        }
     }
 
     public Player getPlayer() {


### PR DESCRIPTION
Allows users to stop headers and footers from being set so it doesn't conflict with external plugins, also updates the resource link