### PR TITLE
Fix NullPointerException

### DIFF
--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/Arena.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/Arena.java
@@ -1815,9 +1815,12 @@ public class Arena implements IArena {
      */
     @Override
     public ITeam getTeam(Player p) {
-        for (ITeam t : getTeams()) {
-            if (t.isMember(p)) {
-                return t;
+        List<ITeam> teams = getTeams();
+        if (teams != null) {
+            for (ITeam t : teams) {
+                if (t.isMember(p)) {
+                    return t;
+                }
             }
         }
         return null;
@@ -1829,9 +1832,12 @@ public class Arena implements IArena {
      */
     @Override
     public ITeam getExTeam(UUID p) {
-        for (ITeam t : getTeams()) {
-            if (t.wasMember(p)) {
-                return t;
+        List<ITeam> teams = getTeams();
+        if (teams != null) {
+            for (ITeam t : teams) {
+                if (t != null && t.wasMember(p)) {
+                    return t;
+                }
             }
         }
         return null;


### PR DESCRIPTION
Fixed NullPointerException error in getTeam method and getExTeam method.

Why did I get an error? https://www.spigotmc.org/resources/play-again-addon-%E2%AD%90-bedwars1058-%E2%AD%95-1-8-1-20.104653/ This is because when I used it and added the next game, an error occurred when I started the game.