### PR TITLE
fix SidebarLib throwing NPE on 1.17, 1.18 and 1.19 r2

### DIFF
--- a/bedwars-plugin/pom.xml
+++ b/bedwars-plugin/pom.xml
@@ -247,61 +247,61 @@
         <dependency>
             <groupId>com.andrei1058.spigot.sidebar</groupId>
             <artifactId>sidebar-base</artifactId>
-            <version>23.10</version>
+            <version>23.12</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.andrei1058.spigot.sidebar</groupId>
             <artifactId>sidebar-v1_8_R3</artifactId>
-            <version>23.10</version>
+            <version>23.12</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.andrei1058.spigot.sidebar</groupId>
             <artifactId>sidebar-v1_12_R1</artifactId>
-            <version>23.10</version>
+            <version>23.12</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.andrei1058.spigot.sidebar</groupId>
             <artifactId>sidebar-v1_16_R1</artifactId>
-            <version>23.10</version>
+            <version>23.12</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.andrei1058.spigot.sidebar</groupId>
             <artifactId>sidebar-v1_17_R1</artifactId>
-            <version>23.10</version>
+            <version>23.12</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.andrei1058.spigot.sidebar</groupId>
             <artifactId>sidebar-v1_18_R2</artifactId>
-            <version>23.10</version>
+            <version>23.12</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.andrei1058.spigot.sidebar</groupId>
             <artifactId>sidebar-v1_19_R2</artifactId>
-            <version>23.10</version>
+            <version>23.12</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.andrei1058.spigot.sidebar</groupId>
             <artifactId>sidebar-v1_19_R3</artifactId>
-            <version>23.10</version>
+            <version>23.12</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.andrei1058.spigot.sidebar</groupId>
             <artifactId>sidebar-v1_20_R1</artifactId>
-            <version>23.10</version>
+            <version>23.12</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.andrei1058.spigot.sidebar</groupId>
             <artifactId>sidebar-v1_20_R2</artifactId>
-            <version>23.10</version>
+            <version>23.12</version>
             <scope>compile</scope>
         </dependency>
         <!--        End of Sidebar LIB-->


### PR DESCRIPTION
fix #930