### PR TITLE
fix default blast protection configuration from fireballs on 1.8.8

### DIFF
--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/configuration/MainConfig.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/configuration/MainConfig.java
@@ -116,7 +116,8 @@ public class MainConfig extends ConfigManager {
         yml.addDefault(ConfigPath.GENERAL_TNT_JUMP_DAMAGE_OTHERS, 10);
 
         // tnd block blast resistance
-        yml.addDefault(ConfigPath.GENERAL_TNT_PROTECTION_END_STONE_BLAST, 12f);
+        // on 1.8.8 it has to be around 69, on 1.20 and 1.18 it works fine with 12 (tested)
+        yml.addDefault(ConfigPath.GENERAL_TNT_PROTECTION_END_STONE_BLAST, BedWars.nms.getVersion() == 0 ? 69f : 12f);
         yml.addDefault(ConfigPath.GENERAL_TNT_PROTECTION_GLASS_BLAST, 300f);
         yml.addDefault(ConfigPath.GENERAL_TNT_RAY_BLOCKED_BY_GLASS, true);
 
@@ -382,6 +383,7 @@ public class MainConfig extends ConfigManager {
         try {
             Bukkit.spigot().getConfig().save("spigot.yml");
         } catch (IOException e) {
+            //noinspection CallToPrintStackTrace
             e.printStackTrace();
         }
 


### PR DESCRIPTION
- fix #936 