### PR TITLE
Release 23.12.1

### DIFF
--- a/.github/workflows/compile_snapshot.yml
+++ b/.github/workflows/compile_snapshot.yml
@@ -10,9 +10,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    environment:
-      name: development
-      url: https://repo.andrei1058.dev
+#    environment:
+#      name: development
+#      url: https://repo.andrei1058.dev
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: production
-      url: https://repo.andrei1058.com
+      url: https://repo.andrei1058.dev
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK

--- a/.github/workflows/deploy_snapshot.yml
+++ b/.github/workflows/deploy_snapshot.yml
@@ -1,9 +1,11 @@
 name: Deploy snapshot with Maven
 
 on:
-  push:
+  pull_request:
     branches:
       - develop
+    types:
+      - closed
 
 jobs:
   build:

--- a/.github/workflows/deploy_snapshot.yml
+++ b/.github/workflows/deploy_snapshot.yml
@@ -6,7 +6,6 @@ on:
       - develop
 jobs:
   build:
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     environment:
       name: development

--- a/.github/workflows/deploy_snapshot.yml
+++ b/.github/workflows/deploy_snapshot.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     environment:
       name: development

--- a/.github/workflows/deploy_snapshot.yml
+++ b/.github/workflows/deploy_snapshot.yml
@@ -1,12 +1,9 @@
 name: Deploy snapshot with Maven
 
 on:
-  pull_request:
+  push:
     branches:
       - develop
-    types:
-      - closed
-
 jobs:
   build:
     if: github.event.pull_request.merged == true

--- a/bedwars-api/pom.xml
+++ b/bedwars-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>BedWars1058</artifactId>
         <groupId>com.andrei1058.bedwars</groupId>
-        <version>23.10.1-SNAPSHOT</version>
+        <version>23.12.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>bedwars-api</artifactId>

--- a/bedwars-plugin/pom.xml
+++ b/bedwars-plugin/pom.xml
@@ -247,61 +247,61 @@
         <dependency>
             <groupId>com.andrei1058.spigot.sidebar</groupId>
             <artifactId>sidebar-base</artifactId>
-            <version>23.10</version>
+            <version>23.12</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.andrei1058.spigot.sidebar</groupId>
             <artifactId>sidebar-v1_8_R3</artifactId>
-            <version>23.10</version>
+            <version>23.12</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.andrei1058.spigot.sidebar</groupId>
             <artifactId>sidebar-v1_12_R1</artifactId>
-            <version>23.10</version>
+            <version>23.12</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.andrei1058.spigot.sidebar</groupId>
             <artifactId>sidebar-v1_16_R1</artifactId>
-            <version>23.10</version>
+            <version>23.12</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.andrei1058.spigot.sidebar</groupId>
             <artifactId>sidebar-v1_17_R1</artifactId>
-            <version>23.10</version>
+            <version>23.12</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.andrei1058.spigot.sidebar</groupId>
             <artifactId>sidebar-v1_18_R2</artifactId>
-            <version>23.10</version>
+            <version>23.12</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.andrei1058.spigot.sidebar</groupId>
             <artifactId>sidebar-v1_19_R2</artifactId>
-            <version>23.10</version>
+            <version>23.12</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.andrei1058.spigot.sidebar</groupId>
             <artifactId>sidebar-v1_19_R3</artifactId>
-            <version>23.10</version>
+            <version>23.12</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.andrei1058.spigot.sidebar</groupId>
             <artifactId>sidebar-v1_20_R1</artifactId>
-            <version>23.10</version>
+            <version>23.12</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.andrei1058.spigot.sidebar</groupId>
             <artifactId>sidebar-v1_20_R2</artifactId>
-            <version>23.10</version>
+            <version>23.12</version>
             <scope>compile</scope>
         </dependency>
         <!--        End of Sidebar LIB-->

--- a/bedwars-plugin/pom.xml
+++ b/bedwars-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>BedWars1058</artifactId>
         <groupId>com.andrei1058.bedwars</groupId>
-        <version>23.10.1-SNAPSHOT</version>
+        <version>23.12.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>bedwars-plugin</artifactId>
@@ -194,6 +194,11 @@
         </dependency>
         <dependency>
             <groupId>com.andrei1058.bedwars</groupId>
+            <artifactId>versionsupport_v1_20_R3</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.andrei1058.bedwars</groupId>
             <artifactId>versionsupport-common</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -247,7 +252,7 @@
         <dependency>
             <groupId>com.andrei1058.spigot.sidebar</groupId>
             <artifactId>sidebar-base</artifactId>
-            <version>23.12</version>
+            <version>23.12.1-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -302,6 +307,12 @@
             <groupId>com.andrei1058.spigot.sidebar</groupId>
             <artifactId>sidebar-v1_20_R2</artifactId>
             <version>23.12</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.andrei1058.spigot.sidebar</groupId>
+            <artifactId>sidebar-v1_20_R3</artifactId>
+            <version>23.12.1-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <!--        End of Sidebar LIB-->

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/BedWars.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/BedWars.java
@@ -516,6 +516,9 @@ public class BedWars extends JavaPlugin {
 
         // TNT Spoil Feature
         SpoilPlayerTNTFeature.init();
+
+        // Warn user if current server version support is deprecated
+        this.performDeprecationCheck();
     }
 
     /**
@@ -751,6 +754,15 @@ public class BedWars extends JavaPlugin {
 
     public static void setParty(Party party) {
         BedWars.party = party;
+    }
+
+    public void performDeprecationCheck() {
+        Bukkit.getScheduler().runTaskAsynchronously(this, () -> {
+            if (Arrays.stream(nms.getClass().getAnnotations()).anyMatch(annotation -> annotation instanceof Deprecated)) {
+                this.getLogger().warning("Support for "+getServerVersion()+" is scheduled for removal. " +
+                        "Please consider upgrading your server software to a newer Minecraft version.");
+            }
+        });
     }
 
     @Override

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/configuration/MainConfig.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/configuration/MainConfig.java
@@ -116,7 +116,8 @@ public class MainConfig extends ConfigManager {
         yml.addDefault(ConfigPath.GENERAL_TNT_JUMP_DAMAGE_OTHERS, 10);
 
         // tnd block blast resistance
-        yml.addDefault(ConfigPath.GENERAL_TNT_PROTECTION_END_STONE_BLAST, 12f);
+        // on 1.8.8 it has to be around 69, on 1.20 and 1.18 it works fine with 12 (tested)
+        yml.addDefault(ConfigPath.GENERAL_TNT_PROTECTION_END_STONE_BLAST, BedWars.nms.getVersion() == 0 ? 69f : 12f);
         yml.addDefault(ConfigPath.GENERAL_TNT_PROTECTION_GLASS_BLAST, 300f);
         yml.addDefault(ConfigPath.GENERAL_TNT_RAY_BLOCKED_BY_GLASS, true);
 
@@ -382,6 +383,7 @@ public class MainConfig extends ConfigManager {
         try {
             Bukkit.spigot().getConfig().save("spigot.yml");
         } catch (IOException e) {
+            //noinspection CallToPrintStackTrace
             e.printStackTrace();
         }
 

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/metrics/MetricsManager.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/metrics/MetricsManager.java
@@ -15,7 +15,7 @@ public class MetricsManager {
     private final Metrics metrics;
 
     private MetricsManager(BedWars plugin) {
-        metrics = new Metrics(plugin, 97320);
+        metrics = new Metrics(plugin, 1885);
 
         // base metrics
         metrics.addCustomChart(new SimplePie("server_type", () -> BedWars.getServerType().toString()));

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/sidebar/BwSidebar.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/sidebar/BwSidebar.java
@@ -136,6 +136,7 @@ public class BwSidebar implements ISidebar {
         for (String line : lineArray) {
             // convert old placeholders
             line = line.replace("{server_ip}", "{serverIp}");
+            String scoreLine = null;
 
             // generic team placeholder {team}
             if (null != arena) {
@@ -148,9 +149,14 @@ public class BwSidebar implements ISidebar {
                         line = genericTeamFormat
                                 .replace("{TeamLetter}", teamLetter)
                                 .replace("{TeamColor}", team.getColor().chat().toString())
-                                .replace("{TeamName}", teamName)
-                                .replace("{TeamStatus}", "{Team" + team.getName() + "Status}");
+                                .replace("{TeamName}", teamName);
 
+                        if (line.contains("{TeamStatus}") && getAPI().getVersionSupport().getVersion() >= 10) {
+                            line = line.replace("{TeamStatus}", "");
+                            scoreLine = "{Team" + team.getName() + "Status}";
+                        } else {
+                            line = line.replace("{TeamStatus}", "{Team" + team.getName() + "Status}");
+                        }
                     } else {
                         // skip line
                         continue;
@@ -223,12 +229,7 @@ public class BwSidebar implements ISidebar {
             if (divided.length > 1) {
                 sidebarLine = normalizeTitle(Arrays.asList(divided));
             } else {
-                sidebarLine = new SidebarLine() {
-                    @Override
-                    public @NotNull String getLine() {
-                        return finalTemp;
-                    }
-                };
+                sidebarLine = new BwSidebarLine(finalTemp, scoreLine);
             }
 
             lines.add(sidebarLine);

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/sidebar/BwSidebarLine.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/sidebar/BwSidebarLine.java
@@ -1,0 +1,26 @@
+package com.andrei1058.bedwars.sidebar;
+
+import com.andrei1058.spigot.sidebar.ScoredLine;
+import com.andrei1058.spigot.sidebar.SidebarLine;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class BwSidebarLine extends SidebarLine implements ScoredLine {
+
+    public final String content;
+    public final String score;
+
+    public BwSidebarLine(String content, @Nullable String score) {
+        this.content = content;
+        this.score = score == null ? "" : score;
+    }
+    @Override
+    public String getScore() {
+        return score;
+    }
+
+    @Override
+    public @NotNull String getLine() {
+        return content;
+    }
+}

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/sidebar/SidebarService.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/sidebar/SidebarService.java
@@ -62,7 +62,7 @@ public class SidebarService implements ISidebarService {
                 }
                 Bukkit.getScheduler().runTaskTimer(plugin, new RefreshPlaceholdersTask(), 1L, placeholdersRefreshInterval);
             }
-            MetricsManager.appendPie("sb_placeholder_refresh_interval", () -> String.valueOf(playerListRefreshInterval));
+            MetricsManager.appendPie("sb_placeholder_refresh_interval", () -> String.valueOf(placeholdersRefreshInterval));
 
             int titleRefreshInterval = config.getInt(ConfigPath.SB_CONFIG_SIDEBAR_TITLE_REFRESH_INTERVAL);
             if (titleRefreshInterval < 1) {

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.andrei1058.bedwars</groupId>
     <artifactId>BedWars1058</artifactId>
     <packaging>pom</packaging>
-    <version>23.10.1-SNAPSHOT</version>
+    <version>23.12.1-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -113,6 +113,7 @@
         <module>versionsupport_v1_19_R3</module>
         <module>versionsupport_v1_20_R1</module>
         <module>versionsupport_v1_20_R2</module>
+        <module>versionsupport_v1_20_R3</module>
     </modules>
 
     <distributionManagement>

--- a/resetadapter_aswm/pom.xml
+++ b/resetadapter_aswm/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>BedWars1058</artifactId>
         <groupId>com.andrei1058.bedwars</groupId>
-        <version>23.10.1-SNAPSHOT</version>
+        <version>23.12.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>resetadapter-aswm</artifactId>

--- a/resetadapter_slime/pom.xml
+++ b/resetadapter_slime/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>BedWars1058</artifactId>
         <groupId>com.andrei1058.bedwars</groupId>
-        <version>23.10.1-SNAPSHOT</version>
+        <version>23.12.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>resetadapter-slime</artifactId>

--- a/resetadapter_slimepaper/pom.xml
+++ b/resetadapter_slimepaper/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>BedWars1058</artifactId>
         <groupId>com.andrei1058.bedwars</groupId>
-        <version>23.10.1-SNAPSHOT</version>
+        <version>23.12.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>resetadapter-slimepaper</artifactId>

--- a/versionsupport_1_12_R1/pom.xml
+++ b/versionsupport_1_12_R1/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>BedWars1058</artifactId>
         <groupId>com.andrei1058.bedwars</groupId>
-        <version>23.10.1-SNAPSHOT</version>
+        <version>23.12.1-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/versionsupport_1_8_R3/pom.xml
+++ b/versionsupport_1_8_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>BedWars1058</artifactId>
         <groupId>com.andrei1058.bedwars</groupId>
-        <version>23.10.1-SNAPSHOT</version>
+        <version>23.12.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>versionsupport_1_8_R3</artifactId>

--- a/versionsupport_1_8_R3/src/main/java/com/andrei1058/bedwars/support/version/v1_8_R3/IGolem.java
+++ b/versionsupport_1_8_R3/src/main/java/com/andrei1058/bedwars/support/version/v1_8_R3/IGolem.java
@@ -36,6 +36,7 @@ import org.bukkit.event.entity.CreatureSpawnEvent;
 import java.lang.reflect.Field;
 
 @SuppressWarnings("ALL")
+@Deprecated
 public class IGolem extends EntityIronGolem {
 
     private ITeam team;

--- a/versionsupport_1_8_R3/src/main/java/com/andrei1058/bedwars/support/version/v1_8_R3/Silverfish.java
+++ b/versionsupport_1_8_R3/src/main/java/com/andrei1058/bedwars/support/version/v1_8_R3/Silverfish.java
@@ -36,6 +36,7 @@ import org.bukkit.event.entity.CreatureSpawnEvent;
 import java.lang.reflect.Field;
 
 @SuppressWarnings("ALL")
+@Deprecated
 public class Silverfish extends EntitySilverfish {
 
     private ITeam team;

--- a/versionsupport_1_8_R3/src/main/java/com/andrei1058/bedwars/support/version/v1_8_R3/v1_8_R3.java
+++ b/versionsupport_1_8_R3/src/main/java/com/andrei1058/bedwars/support/version/v1_8_R3/v1_8_R3.java
@@ -60,6 +60,7 @@ import java.util.logging.Level;
 
 import static com.andrei1058.bedwars.api.language.Language.getMsg;
 
+@Deprecated(forRemoval = true)
 @SuppressWarnings("unused")
 public class v1_8_R3 extends VersionSupport {
 

--- a/versionsupport_common/pom.xml
+++ b/versionsupport_common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>BedWars1058</artifactId>
         <groupId>com.andrei1058.bedwars</groupId>
-        <version>23.10.1-SNAPSHOT</version>
+        <version>23.12.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/versionsupport_v1_16_R3/pom.xml
+++ b/versionsupport_v1_16_R3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>BedWars1058</artifactId>
         <groupId>com.andrei1058.bedwars</groupId>
-        <version>23.10.1-SNAPSHOT</version>
+        <version>23.12.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/versionsupport_v1_17_R1/pom.xml
+++ b/versionsupport_v1_17_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>BedWars1058</artifactId>
         <groupId>com.andrei1058.bedwars</groupId>
-        <version>23.10.1-SNAPSHOT</version>
+        <version>23.12.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/versionsupport_v1_17_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_17_R1/IGolem.java
+++ b/versionsupport_v1_17_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_17_R1/IGolem.java
@@ -47,6 +47,7 @@ import org.bukkit.event.entity.CreatureSpawnEvent;
 import java.util.Objects;
 
 @SuppressWarnings("unchecked")
+@Deprecated
 public class IGolem extends EntityIronGolem {
     private ITeam team;
 

--- a/versionsupport_v1_17_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_17_R1/Silverfish.java
+++ b/versionsupport_v1_17_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_17_R1/Silverfish.java
@@ -43,6 +43,7 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.entity.CreatureSpawnEvent;
 
 @SuppressWarnings("ALL")
+@Deprecated
 public class Silverfish extends EntitySilverfish {
 
     private ITeam team;

--- a/versionsupport_v1_17_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_17_R1/v1_17_R1.java
+++ b/versionsupport_v1_17_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_17_R1/v1_17_R1.java
@@ -93,6 +93,7 @@ import java.util.UUID;
 import java.util.logging.Level;
 
 @SuppressWarnings("unused")
+@Deprecated
 public class v1_17_R1 extends VersionSupport {
 
     private static final UUID chatUUID = new UUID(0L, 0L);

--- a/versionsupport_v1_18_R2/pom.xml
+++ b/versionsupport_v1_18_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>BedWars1058</artifactId>
         <groupId>com.andrei1058.bedwars</groupId>
-        <version>23.10.1-SNAPSHOT</version>
+        <version>23.12.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/versionsupport_v1_19_R2/pom.xml
+++ b/versionsupport_v1_19_R2/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.andrei1058.bedwars</groupId>
         <artifactId>BedWars1058</artifactId>
-        <version>23.10.1-SNAPSHOT</version>
+        <version>23.12.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>versionsupport_v1_19_R2</artifactId>

--- a/versionsupport_v1_19_R2/src/main/java/com/andrei1058/bedwars/support/version/v1_19_R2/despawnable/DespawnableAttributes.java
+++ b/versionsupport_v1_19_R2/src/main/java/com/andrei1058/bedwars/support/version/v1_19_R2/despawnable/DespawnableAttributes.java
@@ -1,5 +1,6 @@
 package com.andrei1058.bedwars.support.version.v1_19_R2.despawnable;
 
+@Deprecated
 public record DespawnableAttributes(DespawnableType type, double speed, double health, double damage, int despawnSeconds) {
 
 }

--- a/versionsupport_v1_19_R2/src/main/java/com/andrei1058/bedwars/support/version/v1_19_R2/despawnable/DespawnableFactory.java
+++ b/versionsupport_v1_19_R2/src/main/java/com/andrei1058/bedwars/support/version/v1_19_R2/despawnable/DespawnableFactory.java
@@ -9,6 +9,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 
+@Deprecated
 public class DespawnableFactory {
 
     private final VersionSupport versionSupport;

--- a/versionsupport_v1_19_R2/src/main/java/com/andrei1058/bedwars/support/version/v1_19_R2/despawnable/DespawnableProvider.java
+++ b/versionsupport_v1_19_R2/src/main/java/com/andrei1058/bedwars/support/version/v1_19_R2/despawnable/DespawnableProvider.java
@@ -17,6 +17,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 
+@Deprecated
 public abstract class DespawnableProvider<T> {
 
     abstract DespawnableType getType();

--- a/versionsupport_v1_19_R2/src/main/java/com/andrei1058/bedwars/support/version/v1_19_R2/despawnable/DespawnableType.java
+++ b/versionsupport_v1_19_R2/src/main/java/com/andrei1058/bedwars/support/version/v1_19_R2/despawnable/DespawnableType.java
@@ -1,5 +1,6 @@
 package com.andrei1058.bedwars.support.version.v1_19_R2.despawnable;
 
+@Deprecated
 public enum DespawnableType {
     IRON_GOLEM,
     SILVERFISH

--- a/versionsupport_v1_19_R2/src/main/java/com/andrei1058/bedwars/support/version/v1_19_R2/despawnable/TeamIronGolem.java
+++ b/versionsupport_v1_19_R2/src/main/java/com/andrei1058/bedwars/support/version/v1_19_R2/despawnable/TeamIronGolem.java
@@ -19,6 +19,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 
+@Deprecated
 public class TeamIronGolem extends DespawnableProvider<IronGolem> {
 
     @Override

--- a/versionsupport_v1_19_R2/src/main/java/com/andrei1058/bedwars/support/version/v1_19_R2/despawnable/TeamSilverfish.java
+++ b/versionsupport_v1_19_R2/src/main/java/com/andrei1058/bedwars/support/version/v1_19_R2/despawnable/TeamSilverfish.java
@@ -19,6 +19,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 
+@Deprecated
 public class TeamSilverfish extends DespawnableProvider<Silverfish> {
     @Override
     public DespawnableType getType() {

--- a/versionsupport_v1_19_R2/src/main/java/com/andrei1058/bedwars/support/version/v1_19_R2/v1_19_R2.java
+++ b/versionsupport_v1_19_R2/src/main/java/com/andrei1058/bedwars/support/version/v1_19_R2/v1_19_R2.java
@@ -65,6 +65,7 @@ import java.util.List;
 import java.util.logging.Level;
 
 @SuppressWarnings("unused")
+@Deprecated
 public class v1_19_R2 extends VersionSupport {
 
     private final DespawnableFactory despawnableFactory;

--- a/versionsupport_v1_20_R1/pom.xml
+++ b/versionsupport_v1_20_R1/pom.xml
@@ -12,8 +12,8 @@
     <artifactId>versionsupport_v1_20_R1</artifactId>
 
     <properties>
-        <maven.compiler.source>1.17</maven.compiler.source>
-        <maven.compiler.target>1.17</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -54,8 +54,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>
-                    <source>19</source>
-                    <target>19</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/versionsupport_v1_20_R1/pom.xml
+++ b/versionsupport_v1_20_R1/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.andrei1058.bedwars</groupId>
         <artifactId>BedWars1058</artifactId>
-        <version>23.10.1-SNAPSHOT</version>
+        <version>23.12.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>versionsupport_v1_20_R1</artifactId>

--- a/versionsupport_v1_20_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_20_R1/despawnable/DespawnableAttributes.java
+++ b/versionsupport_v1_20_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_20_R1/despawnable/DespawnableAttributes.java
@@ -1,5 +1,6 @@
 package com.andrei1058.bedwars.support.version.v1_20_R1.despawnable;
 
+@Deprecated
 public record DespawnableAttributes(DespawnableType type, double speed, double health, double damage, int despawnSeconds) {
 
 }

--- a/versionsupport_v1_20_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_20_R1/despawnable/DespawnableFactory.java
+++ b/versionsupport_v1_20_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_20_R1/despawnable/DespawnableFactory.java
@@ -9,6 +9,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 
+@Deprecated
 public class DespawnableFactory {
 
     private final VersionSupport versionSupport;

--- a/versionsupport_v1_20_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_20_R1/despawnable/DespawnableProvider.java
+++ b/versionsupport_v1_20_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_20_R1/despawnable/DespawnableProvider.java
@@ -17,6 +17,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 
+@Deprecated
 public abstract class DespawnableProvider<T> {
 
     abstract DespawnableType getType();

--- a/versionsupport_v1_20_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_20_R1/despawnable/DespawnableType.java
+++ b/versionsupport_v1_20_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_20_R1/despawnable/DespawnableType.java
@@ -1,5 +1,6 @@
 package com.andrei1058.bedwars.support.version.v1_20_R1.despawnable;
 
+@Deprecated
 public enum DespawnableType {
     IRON_GOLEM,
     SILVERFISH

--- a/versionsupport_v1_20_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_20_R1/despawnable/TeamIronGolem.java
+++ b/versionsupport_v1_20_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_20_R1/despawnable/TeamIronGolem.java
@@ -19,6 +19,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 
+@Deprecated
 public class TeamIronGolem extends DespawnableProvider<IronGolem> {
 
     @Override

--- a/versionsupport_v1_20_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_20_R1/despawnable/TeamSilverfish.java
+++ b/versionsupport_v1_20_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_20_R1/despawnable/TeamSilverfish.java
@@ -19,6 +19,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 
+@Deprecated
 public class TeamSilverfish extends DespawnableProvider<Silverfish> {
     @Override
     public DespawnableType getType() {

--- a/versionsupport_v1_20_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_20_R1/v1_20_R1.java
+++ b/versionsupport_v1_20_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_20_R1/v1_20_R1.java
@@ -61,6 +61,7 @@ import java.util.*;
 import java.util.logging.Level;
 
 @SuppressWarnings("unused")
+@Deprecated
 public class v1_20_R1 extends VersionSupport {
 
     private final DespawnableFactory despawnableFactory;

--- a/versionsupport_v1_20_R2/pom.xml
+++ b/versionsupport_v1_20_R2/pom.xml
@@ -12,8 +12,8 @@
     <artifactId>versionsupport_v1_20_R2</artifactId>
 
     <properties>
-        <maven.compiler.source>1.17</maven.compiler.source>
-        <maven.compiler.target>1.17</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -54,8 +54,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>
-                    <source>19</source>
-                    <target>19</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/versionsupport_v1_20_R2/pom.xml
+++ b/versionsupport_v1_20_R2/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.andrei1058.bedwars</groupId>
         <artifactId>BedWars1058</artifactId>
-        <version>23.10.1-SNAPSHOT</version>
+        <version>23.12.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>versionsupport_v1_20_R2</artifactId>
@@ -38,6 +38,12 @@
             <version>1.20.2-R0.1-SNAPSHOT</version>
             <type>jar</type>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/versionsupport_v1_20_R3/pom.xml
+++ b/versionsupport_v1_20_R3/pom.xml
@@ -9,11 +9,11 @@
         <version>23.12.1-SNAPSHOT</version>
     </parent>
 
-    <artifactId>versionsupport_v1_19_R3</artifactId>
+    <artifactId>versionsupport_v1_20_R3</artifactId>
 
     <properties>
-        <maven.compiler.source>1.17</maven.compiler.source>
-        <maven.compiler.target>1.17</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -35,9 +35,15 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot</artifactId>
-            <version>1.19.4-R0.1-SNAPSHOT</version>
+            <version>1.20.3-R0.1-SNAPSHOT</version>
             <type>jar</type>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/versionsupport_v1_20_R3/src/main/java/com/andrei1058/bedwars/support/version/v1_20_R3/despawnable/DespawnableAttributes.java
+++ b/versionsupport_v1_20_R3/src/main/java/com/andrei1058/bedwars/support/version/v1_20_R3/despawnable/DespawnableAttributes.java
@@ -1,0 +1,5 @@
+package com.andrei1058.bedwars.support.version.v1_20_R3.despawnable;
+
+public record DespawnableAttributes(DespawnableType type, double speed, double health, double damage, int despawnSeconds) {
+
+}

--- a/versionsupport_v1_20_R3/src/main/java/com/andrei1058/bedwars/support/version/v1_20_R3/despawnable/DespawnableFactory.java
+++ b/versionsupport_v1_20_R3/src/main/java/com/andrei1058/bedwars/support/version/v1_20_R3/despawnable/DespawnableFactory.java
@@ -1,0 +1,27 @@
+package com.andrei1058.bedwars.support.version.v1_20_R3.despawnable;
+
+import com.andrei1058.bedwars.api.arena.team.ITeam;
+import com.andrei1058.bedwars.api.server.VersionSupport;
+import org.bukkit.Location;
+import org.bukkit.entity.LivingEntity;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DespawnableFactory {
+
+    private final VersionSupport versionSupport;
+    private final List<DespawnableProvider<? extends LivingEntity>> providers = new ArrayList<>();
+
+    public DespawnableFactory(VersionSupport versionSupport) {
+        this.versionSupport = versionSupport;
+        providers.add(new TeamIronGolem());
+        providers.add(new TeamSilverfish());
+    }
+
+    public LivingEntity spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team){
+        return providers.stream().filter(provider -> provider.getType() == attr.type())
+                .findFirst().orElseThrow().spawn(attr, location,team, versionSupport);
+    }
+}

--- a/versionsupport_v1_20_R3/src/main/java/com/andrei1058/bedwars/support/version/v1_20_R3/despawnable/DespawnableProvider.java
+++ b/versionsupport_v1_20_R3/src/main/java/com/andrei1058/bedwars/support/version/v1_20_R3/despawnable/DespawnableProvider.java
@@ -1,0 +1,71 @@
+package com.andrei1058.bedwars.support.version.v1_20_R3.despawnable;
+
+import com.andrei1058.bedwars.api.arena.team.ITeam;
+import com.andrei1058.bedwars.api.server.VersionSupport;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityCreature;
+import net.minecraft.world.entity.EntityInsentient;
+import net.minecraft.world.entity.EntityLiving;
+import net.minecraft.world.entity.ai.attributes.GenericAttributes;
+import net.minecraft.world.entity.ai.goal.PathfinderGoal;
+import net.minecraft.world.entity.ai.goal.PathfinderGoalSelector;
+import net.minecraft.world.entity.ai.goal.target.PathfinderGoalNearestAttackableTarget;
+import net.minecraft.world.entity.player.EntityHuman;
+import org.bukkit.Location;
+import org.bukkit.craftbukkit.v1_20_R3.entity.CraftEntity;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+public abstract class DespawnableProvider<T> {
+
+    abstract DespawnableType getType();
+
+    abstract String getDisplayName(DespawnableAttributes attr, ITeam team);
+
+    abstract T spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api);
+
+    protected boolean notSameTeam(@NotNull Entity entity, ITeam team, @NotNull VersionSupport api) {
+        var despawnable = api.getDespawnablesList().getOrDefault(entity.getBukkitEntity().getUniqueId(), null);
+        return null == despawnable || despawnable.getTeam() != team;
+    }
+
+    protected PathfinderGoalSelector getTargetSelector(@NotNull EntityCreature entityLiving) {
+        return entityLiving.bP;
+    }
+
+    protected PathfinderGoalSelector getGoalSelector(@NotNull EntityCreature entityLiving) {
+        return entityLiving.bO;
+    }
+
+    protected void clearSelectors(@NotNull EntityCreature entityLiving) {
+        entityLiving.bO.b().clear();
+        entityLiving.bP.b().clear();
+    }
+
+    protected PathfinderGoal getTargetGoal(EntityInsentient entity, ITeam team, VersionSupport api) {
+        return new PathfinderGoalNearestAttackableTarget<>(entity, EntityLiving.class, 20, true, false,
+                entityLiving -> {
+                    if (entityLiving instanceof EntityHuman) {
+                        return !((EntityHuman) entityLiving).getBukkitEntity().isDead() &&
+                                !team.wasMember(((EntityHuman) entityLiving).getBukkitEntity().getUniqueId()) &&
+                                !team.getArena().isReSpawning(((EntityHuman) entityLiving).getBukkitEntity().getUniqueId())
+                                && !team.getArena().isSpectator(((EntityHuman) entityLiving).getBukkitEntity().getUniqueId());
+                    }
+                    return notSameTeam(entityLiving, team, api);
+                });
+    }
+
+    protected void applyDefaultSettings(org.bukkit.entity.@NotNull LivingEntity bukkitEntity, DespawnableAttributes attr,
+                                        ITeam team) {
+        bukkitEntity.setRemoveWhenFarAway(false);
+        bukkitEntity.setPersistent(true);
+        bukkitEntity.setCustomNameVisible(true);
+        bukkitEntity.setCustomName(getDisplayName(attr, team));
+
+        var entity = ((EntityInsentient)((CraftEntity)bukkitEntity).getHandle());
+        Objects.requireNonNull(entity.a(GenericAttributes.a)).a(attr.health());
+        Objects.requireNonNull(entity.a(GenericAttributes.d)).a(attr.speed());
+        Objects.requireNonNull(entity.a(GenericAttributes.f)).a(attr.damage());
+    }
+}

--- a/versionsupport_v1_20_R3/src/main/java/com/andrei1058/bedwars/support/version/v1_20_R3/despawnable/DespawnableType.java
+++ b/versionsupport_v1_20_R3/src/main/java/com/andrei1058/bedwars/support/version/v1_20_R3/despawnable/DespawnableType.java
@@ -1,0 +1,6 @@
+package com.andrei1058.bedwars.support.version.v1_20_R3.despawnable;
+
+public enum DespawnableType {
+    IRON_GOLEM,
+    SILVERFISH
+}

--- a/versionsupport_v1_20_R3/src/main/java/com/andrei1058/bedwars/support/version/v1_20_R3/despawnable/TeamIronGolem.java
+++ b/versionsupport_v1_20_R3/src/main/java/com/andrei1058/bedwars/support/version/v1_20_R3/despawnable/TeamIronGolem.java
@@ -1,0 +1,58 @@
+package com.andrei1058.bedwars.support.version.v1_20_R3.despawnable;
+
+import com.andrei1058.bedwars.api.arena.team.ITeam;
+import com.andrei1058.bedwars.api.language.Language;
+import com.andrei1058.bedwars.api.language.Messages;
+import com.andrei1058.bedwars.api.server.VersionSupport;
+import net.minecraft.world.entity.ai.goal.PathfinderGoalFloat;
+import net.minecraft.world.entity.ai.goal.PathfinderGoalMeleeAttack;
+import net.minecraft.world.entity.ai.goal.PathfinderGoalRandomLookaround;
+import net.minecraft.world.entity.ai.goal.PathfinderGoalRandomStroll;
+import net.minecraft.world.entity.ai.goal.target.PathfinderGoalHurtByTarget;
+import net.minecraft.world.entity.animal.EntityIronGolem;
+import org.apache.commons.lang.StringUtils;
+import org.bukkit.Location;
+import org.bukkit.craftbukkit.v1_20_R3.entity.CraftEntity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.IronGolem;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+public class TeamIronGolem extends DespawnableProvider<IronGolem> {
+
+    @Override
+    public DespawnableType getType() {
+        return DespawnableType.IRON_GOLEM;
+    }
+
+    @Override
+    String getDisplayName(@NotNull DespawnableAttributes attr, @NotNull ITeam team) {
+        Language lang = Language.getDefaultLanguage();
+        return lang.m(Messages.SHOP_UTILITY_NPC_IRON_GOLEM_NAME).replace("{despawn}", String.valueOf(attr.despawnSeconds())
+                .replace("{health}", StringUtils.repeat(lang.m(Messages.FORMATTING_DESPAWNABLE_UTILITY_NPC_HEALTH) + " ", 10))
+                .replace("{TeamColor}", team.getColor().chat().toString())
+        );
+    }
+
+    public @NotNull IronGolem spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api) {
+
+        var bukkitEntity = (IronGolem) Objects.requireNonNull(location.getWorld()).spawnEntity(location, EntityType.IRON_GOLEM);
+        applyDefaultSettings(bukkitEntity, attr, team);
+
+        var entity = (EntityIronGolem) ((CraftEntity) bukkitEntity).getHandle();
+
+        clearSelectors(entity);
+        var goalSelector = getGoalSelector(entity);
+        var targetSelector = getTargetSelector(entity);
+
+        goalSelector.a(1, new PathfinderGoalFloat(entity));
+        goalSelector.a(2, new PathfinderGoalMeleeAttack(entity, 1.5D, false));
+        goalSelector.a(3, new PathfinderGoalRandomStroll(entity, 1D));
+        goalSelector.a(4, new PathfinderGoalRandomLookaround(entity));
+        targetSelector.a(1, new PathfinderGoalHurtByTarget(entity));
+        targetSelector.a(2, getTargetGoal(entity, team, api));
+
+        return bukkitEntity;
+    }
+}

--- a/versionsupport_v1_20_R3/src/main/java/com/andrei1058/bedwars/support/version/v1_20_R3/despawnable/TeamSilverfish.java
+++ b/versionsupport_v1_20_R3/src/main/java/com/andrei1058/bedwars/support/version/v1_20_R3/despawnable/TeamSilverfish.java
@@ -1,0 +1,56 @@
+package com.andrei1058.bedwars.support.version.v1_20_R3.despawnable;
+
+import com.andrei1058.bedwars.api.arena.team.ITeam;
+import com.andrei1058.bedwars.api.language.Language;
+import com.andrei1058.bedwars.api.language.Messages;
+import com.andrei1058.bedwars.api.server.VersionSupport;
+import net.minecraft.world.entity.ai.goal.PathfinderGoalFloat;
+import net.minecraft.world.entity.ai.goal.PathfinderGoalMeleeAttack;
+import net.minecraft.world.entity.ai.goal.PathfinderGoalRandomLookaround;
+import net.minecraft.world.entity.ai.goal.PathfinderGoalRandomStroll;
+import net.minecraft.world.entity.ai.goal.target.PathfinderGoalHurtByTarget;
+import net.minecraft.world.entity.monster.EntitySilverfish;
+import org.apache.commons.lang.StringUtils;
+import org.bukkit.Location;
+import org.bukkit.craftbukkit.v1_20_R3.entity.CraftEntity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Silverfish;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+public class TeamSilverfish extends DespawnableProvider<Silverfish> {
+    @Override
+    public DespawnableType getType() {
+        return DespawnableType.SILVERFISH;
+    }
+
+    @Override
+    String getDisplayName(@NotNull DespawnableAttributes attr, @NotNull ITeam team) {
+        Language lang = Language.getDefaultLanguage();
+        return lang.m(Messages.SHOP_UTILITY_NPC_SILVERFISH_NAME).replace("{despawn}", String.valueOf(attr.despawnSeconds())
+                .replace("{health}", StringUtils.repeat(lang.m(Messages.FORMATTING_DESPAWNABLE_UTILITY_NPC_HEALTH) + " ", 10))
+                .replace("{TeamColor}", team.getColor().chat().toString())
+        );
+    }
+
+    @Override
+    public Silverfish spawn(@NotNull DespawnableAttributes attr, @NotNull Location location, @NotNull ITeam team, VersionSupport api) {
+        var bukkitEntity = (Silverfish) Objects.requireNonNull(location.getWorld()).spawnEntity(location, EntityType.SILVERFISH);
+        applyDefaultSettings(bukkitEntity, attr, team);
+
+        var entity = (EntitySilverfish) ((CraftEntity) bukkitEntity).getHandle();
+        clearSelectors(entity);
+
+        var goalSelector = getGoalSelector(entity);
+        var targetSelector = getTargetSelector(entity);
+        goalSelector.a(1, new PathfinderGoalFloat(entity));
+        goalSelector.a(2, new PathfinderGoalMeleeAttack(entity, 1.9D, false));
+        goalSelector.a(3, new PathfinderGoalRandomStroll(entity, 2D));
+        goalSelector.a(4, new PathfinderGoalRandomLookaround(entity));
+        targetSelector.a(1, new PathfinderGoalHurtByTarget(entity));
+        targetSelector.a(2, getTargetGoal(entity, team, api));
+
+        return bukkitEntity;
+    }
+}

--- a/versionsupport_v1_20_R3/src/main/java/com/andrei1058/bedwars/support/version/v1_20_R3/v1_20_R3.java
+++ b/versionsupport_v1_20_R3/src/main/java/com/andrei1058/bedwars/support/version/v1_20_R3/v1_20_R3.java
@@ -1,0 +1,838 @@
+package com.andrei1058.bedwars.support.version.v1_20_R3;
+
+import com.andrei1058.bedwars.api.arena.IArena;
+import com.andrei1058.bedwars.api.arena.shop.ShopHolo;
+import com.andrei1058.bedwars.api.arena.team.ITeam;
+import com.andrei1058.bedwars.api.arena.team.TeamColor;
+import com.andrei1058.bedwars.api.entity.Despawnable;
+import com.andrei1058.bedwars.api.events.player.PlayerKillEvent;
+import com.andrei1058.bedwars.api.language.Language;
+import com.andrei1058.bedwars.api.language.Messages;
+import com.andrei1058.bedwars.api.server.VersionSupport;
+import com.andrei1058.bedwars.support.version.common.VersionCommon;
+import com.andrei1058.bedwars.support.version.v1_20_R3.despawnable.DespawnableAttributes;
+import com.andrei1058.bedwars.support.version.v1_20_R3.despawnable.DespawnableFactory;
+import com.andrei1058.bedwars.support.version.v1_20_R3.despawnable.DespawnableType;
+import com.mojang.datafixers.util.Pair;
+import net.md_5.bungee.api.ChatMessageType;
+import net.md_5.bungee.api.chat.TextComponent;
+import net.minecraft.core.particles.ParticleParamRedstone;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.*;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.dedicated.DedicatedServer;
+import net.minecraft.server.level.EntityPlayer;
+import net.minecraft.server.network.PlayerConnection;
+import net.minecraft.world.entity.EntityLiving;
+import net.minecraft.world.entity.EnumItemSlot;
+import net.minecraft.world.entity.item.EntityTNTPrimed;
+import net.minecraft.world.entity.projectile.EntityFireball;
+import net.minecraft.world.entity.projectile.IProjectile;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.*;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockBase;
+import org.bukkit.*;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.data.type.Bed;
+import org.bukkit.block.data.type.Ladder;
+import org.bukkit.block.data.type.WallSign;
+import org.bukkit.command.Command;
+import org.bukkit.craftbukkit.v1_20_R3.CraftServer;
+import org.bukkit.craftbukkit.v1_20_R3.entity.*;
+import org.bukkit.craftbukkit.v1_20_R3.inventory.CraftItemStack;
+import org.bukkit.entity.*;
+import org.bukkit.event.inventory.InventoryEvent;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.SkullMeta;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.potion.PotionEffectType;
+import org.bukkit.util.Vector;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.joml.Vector3f;
+
+import java.lang.reflect.Field;
+import java.util.*;
+import java.util.logging.Level;
+
+@SuppressWarnings("unused")
+public class v1_20_R3 extends VersionSupport {
+
+    private final DespawnableFactory despawnableFactory;
+
+    public v1_20_R3(Plugin plugin, String name) {
+        super(plugin, name);
+        loadDefaultEffects();
+        this.despawnableFactory = new DespawnableFactory(this);
+    }
+
+    @Override
+    public void registerVersionListeners() {
+        new VersionCommon(this);
+    }
+
+    @Override
+    public void registerCommand(String name, Command cmd) {
+        ((CraftServer) getPlugin().getServer()).getCommandMap().register(name, cmd);
+    }
+
+    @Override
+    public String getTag(org.bukkit.inventory.ItemStack itemStack, String key) {
+        var tag = getTag(itemStack);
+        return tag == null ? null : tag.e(key) ? tag.l(key) : null;
+    }
+
+    @Override
+    public void sendTitle(@NotNull Player p, String title, String subtitle, int fadeIn, int stay, int fadeOut) {
+        p.sendTitle(title == null ? " " : title, subtitle == null ? " " : subtitle, fadeIn, stay, fadeOut);
+    }
+
+    public void spawnSilverfish(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn, double damage) {
+        var attr = new DespawnableAttributes(DespawnableType.SILVERFISH, speed, health, damage, despawn);
+        var entity = despawnableFactory.spawn(attr, loc, bedWarsTeam);
+
+        new Despawnable(
+                entity,
+                bedWarsTeam, despawn,
+                Messages.SHOP_UTILITY_NPC_SILVERFISH_NAME,
+                PlayerKillEvent.PlayerKillCause.SILVERFISH_FINAL_KILL,
+                PlayerKillEvent.PlayerKillCause.SILVERFISH
+        );
+    }
+
+    @Override
+    public void spawnIronGolem(Location loc, ITeam bedWarsTeam, double speed, double health, int despawn) {
+        var attr = new DespawnableAttributes(DespawnableType.IRON_GOLEM, speed, health, 4, despawn);
+        var entity = despawnableFactory.spawn(attr, loc, bedWarsTeam);
+        new Despawnable(
+                entity,
+                bedWarsTeam, despawn,
+                Messages.SHOP_UTILITY_NPC_IRON_GOLEM_NAME,
+                PlayerKillEvent.PlayerKillCause.IRON_GOLEM_FINAL_KILL,
+                PlayerKillEvent.PlayerKillCause.IRON_GOLEM
+        );
+    }
+
+    @Override
+    public void playAction(@NotNull Player p, String text) {
+        p.spigot().sendMessage(
+                ChatMessageType.ACTION_BAR,
+                new TextComponent(ChatColor.translateAlternateColorCodes('&', text)
+                )
+        );
+    }
+
+    @Override
+    public boolean isBukkitCommandRegistered(String name) {
+        return ((CraftServer) getPlugin().getServer()).getCommandMap().getCommand(name) != null;
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack getItemInHand(@NotNull Player p) {
+        return p.getInventory().getItemInMainHand();
+    }
+
+    @Override
+    public void hideEntity(@NotNull Entity e, Player p) {
+        PacketPlayOutEntityDestroy packet = new PacketPlayOutEntityDestroy(e.getEntityId());
+        this.sendPacket(p, packet);
+    }
+
+    @Override
+    public void minusAmount(Player p, org.bukkit.inventory.@NotNull ItemStack i, int amount) {
+        if (i.getAmount() - amount <= 0) {
+            if (p.getInventory().getItemInOffHand().equals(i)) {
+                p.getInventory().setItemInOffHand(null);
+            } else {
+                p.getInventory().removeItem(i);
+            }
+            return;
+        }
+        i.setAmount(i.getAmount() - amount);
+
+        // todo this is marked as unstable on 1.20 for some reason
+        p.updateInventory();
+    }
+
+    @Override
+    public void setSource(TNTPrimed tnt, Player owner) {
+        EntityLiving nmsEntityLiving = (((CraftLivingEntity) owner).getHandle());
+        EntityTNTPrimed nmsTNT = (((CraftTNTPrimed) tnt).getHandle());
+        try {
+            Field sourceField = EntityTNTPrimed.class.getDeclaredField("d");
+            sourceField.setAccessible(true);
+            sourceField.set(nmsTNT, nmsEntityLiving);
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
+    }
+
+    @Override
+    public boolean isArmor(org.bukkit.inventory.ItemStack itemStack) {
+        var i = getItem(itemStack);
+        if (null == i) return false;
+        return i instanceof ItemArmor || i instanceof ItemElytra;
+
+    }
+
+    @Override
+    public boolean isTool(org.bukkit.inventory.ItemStack itemStack) {
+        var i = getItem(itemStack);
+        if (null == i) return false;
+        return i instanceof ItemTool;
+    }
+
+    @Override
+    public boolean isSword(org.bukkit.inventory.ItemStack itemStack) {
+        var i = getItem(itemStack);
+        if (null == i) return false;
+        return i instanceof ItemSword;
+    }
+
+    @Override
+    public boolean isAxe(org.bukkit.inventory.ItemStack itemStack) {
+        var i = getItem(itemStack);
+        if (null == i) return false;
+        return i instanceof ItemAxe;
+    }
+
+    @Override
+    public boolean isBow(org.bukkit.inventory.ItemStack itemStack) {
+        var i = getItem(itemStack);
+        if (null == i) return false;
+        return i instanceof ItemBow;
+    }
+
+    @Override
+    public boolean isProjectile(org.bukkit.inventory.ItemStack itemStack) {
+        var entity = getEntity(itemStack);
+        if (null == entity) return false;
+        return entity instanceof IProjectile;
+    }
+
+    @Override
+    public boolean isInvisibilityPotion(org.bukkit.inventory.@NotNull ItemStack itemStack) {
+        if (!itemStack.getType().equals(org.bukkit.Material.POTION)) return false;
+
+        org.bukkit.inventory.meta.PotionMeta pm = (org.bukkit.inventory.meta.PotionMeta) itemStack.getItemMeta();
+
+        return pm != null && pm.hasCustomEffects() && pm.hasCustomEffect(org.bukkit.potion.PotionEffectType.INVISIBILITY);
+    }
+
+    @Override
+    public void registerEntities() {
+    }
+
+    @Override
+    public void spawnShop(@NotNull Location loc, String name1, List<Player> players, IArena arena) {
+        Location l = loc.clone();
+
+        if (l.getWorld() == null) return;
+        Villager vlg = (Villager) l.getWorld().spawnEntity(loc, EntityType.VILLAGER);
+        vlg.setAI(false);
+        vlg.setRemoveWhenFarAway(false);
+        vlg.setCollidable(false);
+        vlg.setInvulnerable(true);
+        vlg.setSilent(true);
+
+        for (Player p : players) {
+            String[] name = Language.getMsg(p, name1).split(",");
+            if (name.length == 1) {
+                ArmorStand a = createArmorStand(name[0], l.clone().add(0, 1.85, 0));
+                new ShopHolo(Language.getPlayerLanguage(p).getIso(), a, null, l, arena);
+            } else {
+                ArmorStand a = createArmorStand(name[0], l.clone().add(0, 2.1, 0));
+                ArmorStand b = createArmorStand(name[1], l.clone().add(0, 1.85, 0));
+                new ShopHolo(Language.getPlayerLanguage(p).getIso(), a, b, l, arena);
+            }
+        }
+        for (ShopHolo sh : ShopHolo.getShopHolo()) {
+            if (sh.getA() == arena) {
+                sh.update();
+            }
+        }
+    }
+
+    @Override
+    public double getDamage(org.bukkit.inventory.ItemStack i) {
+        var tag = getTag(i);
+        if (null == tag) {
+            throw new RuntimeException("Provided item has no Tag");
+        }
+        return tag.k("generic.attackDamage");
+    }
+
+    private static ArmorStand createArmorStand(String name, Location loc) {
+        if (loc == null) return null;
+        if (loc.getWorld() == null) return null;
+        ArmorStand a = loc.getWorld().spawn(loc, ArmorStand.class);
+        a.setGravity(false);
+        a.setVisible(false);
+        a.setCustomNameVisible(true);
+        a.setCustomName(name);
+        return a;
+    }
+
+    @Override
+    public void voidKill(Player p) {
+        EntityPlayer player = getPlayer(p);
+        player.a(player.dN().m(), 1000);
+    }
+
+    @Override
+    public void hideArmor(@NotNull Player victim, Player receiver) {
+        List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
+        items.add(new Pair<>(EnumItemSlot.f, new ItemStack(Item.b(0))));
+        items.add(new Pair<>(EnumItemSlot.e, new ItemStack(Item.b(0))));
+        items.add(new Pair<>(EnumItemSlot.d, new ItemStack(Item.b(0))));
+        items.add(new Pair<>(EnumItemSlot.c, new ItemStack(Item.b(0))));
+        PacketPlayOutEntityEquipment packet1 = new PacketPlayOutEntityEquipment(victim.getEntityId(), items);
+        sendPacket(receiver, packet1);
+    }
+
+    @Override
+    public void showArmor(@NotNull Player victim, Player receiver) {
+        List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
+        items.add(new Pair<>(EnumItemSlot.f, CraftItemStack.asNMSCopy(victim.getInventory().getHelmet())));
+        items.add(new Pair<>(EnumItemSlot.e, CraftItemStack.asNMSCopy(victim.getInventory().getChestplate())));
+        items.add(new Pair<>(EnumItemSlot.d, CraftItemStack.asNMSCopy(victim.getInventory().getLeggings())));
+        items.add(new Pair<>(EnumItemSlot.c, CraftItemStack.asNMSCopy(victim.getInventory().getBoots())));
+        PacketPlayOutEntityEquipment packet1 = new PacketPlayOutEntityEquipment(victim.getEntityId(), items);
+        sendPacket(receiver, packet1);
+    }
+
+    @Override
+    public void spawnDragon(Location l, ITeam bwt) {
+        if (l == null || l.getWorld() == null) {
+            getPlugin().getLogger().log(Level.WARNING, "Could not spawn Dragon. Location is null");
+            return;
+        }
+        EnderDragon ed = (EnderDragon) l.getWorld().spawnEntity(l, EntityType.ENDER_DRAGON);
+        ed.setPhase(EnderDragon.Phase.CIRCLING);
+    }
+
+    @Override
+    public void colorBed(ITeam bwt) {
+        for (int x = -1; x <= 1; x++) {
+            for (int z = -1; z <= 1; z++) {
+                BlockState bed = bwt.getBed().clone().add(x, 0, z).getBlock().getState();
+                if (bed instanceof Bed) {
+                    bed.setType(bwt.getColor().bedMaterial());
+                    bed.update();
+                }
+            }
+        }
+    }
+
+    @Override
+    public void registerTntWhitelist(float endStoneBlast, float glassBlast) {
+        try {
+            // blast resistance
+            Field field = BlockBase.class.getDeclaredField("aH");
+            field.setAccessible(true);
+            // end stone
+            field.set(Blocks.fz, endStoneBlast);
+            // obsidian
+//            field.set(Blocks.co, glassBlast);
+            // standard glass
+            field.set(Blocks.aQ, glassBlast);
+
+            var coloredGlass = new net.minecraft.world.level.block.Block[]{
+                    Blocks.ej, Blocks.ek, Blocks.el, Blocks.em,
+                    Blocks.en, Blocks.eo, Blocks.ep, Blocks.eq,
+                    Blocks.er, Blocks.es, Blocks.et, Blocks.eu,
+                    Blocks.ev, Blocks.ew, Blocks.ex, Blocks.ey,
+
+                    // tinted glass
+                    Blocks.qB,
+            };
+
+            Arrays.stream(coloredGlass).forEach(
+                    glass -> {
+                        try {
+                            field.set(glass, glassBlast);
+                        } catch (IllegalAccessException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+            );
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public void setBlockTeamColor(@NotNull Block block, TeamColor teamColor) {
+        if (block.getType().toString().contains("STAINED_GLASS") || block.getType().toString().equals("GLASS")) {
+            block.setType(teamColor.glassMaterial());
+        } else if (block.getType().toString().contains("_TERRACOTTA")) {
+            block.setType(teamColor.glazedTerracottaMaterial());
+        } else if (block.getType().toString().contains("_WOOL")) {
+            block.setType(teamColor.woolMaterial());
+        }
+    }
+
+    @Override
+    public void setCollide(@NotNull Player p, IArena a, boolean value) {
+        p.setCollidable(value);
+        if (a == null) return;
+        a.updateSpectatorCollideRule(p, value);
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack addCustomData(org.bukkit.inventory.ItemStack i, String data) {
+        var tag = getCreateTag(i);
+        tag.a(VersionSupport.PLUGIN_TAG_GENERIC_KEY, data);
+        return applyTag(i, tag);
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack setTag(org.bukkit.inventory.ItemStack itemStack, String key, String value) {
+        var tag = getCreateTag(itemStack);
+        tag.a(key, value);
+        return applyTag(itemStack, tag);
+    }
+
+    @Override
+    public boolean isCustomBedWarsItem(org.bukkit.inventory.ItemStack i) {
+        return getCreateTag(i).e(VersionSupport.PLUGIN_TAG_GENERIC_KEY);
+    }
+
+    @Override
+    public String getCustomData(org.bukkit.inventory.ItemStack i) {
+        return getCreateTag(i).l(VersionSupport.PLUGIN_TAG_GENERIC_KEY);
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack colourItem(org.bukkit.inventory.ItemStack itemStack, ITeam bedWarsTeam) {
+        if (itemStack == null) return null;
+        String type = itemStack.getType().toString();
+        if (isBed(itemStack.getType())) {
+            return new org.bukkit.inventory.ItemStack(bedWarsTeam.getColor().bedMaterial(), itemStack.getAmount());
+        } else if (type.contains("_STAINED_GLASS_PANE")) {
+            return new org.bukkit.inventory.ItemStack(bedWarsTeam.getColor().glassPaneMaterial(), itemStack.getAmount());
+        } else if (type.contains("STAINED_GLASS") || type.equals("GLASS")) {
+            return new org.bukkit.inventory.ItemStack(bedWarsTeam.getColor().glassMaterial(), itemStack.getAmount());
+        } else if (type.contains("_TERRACOTTA")) {
+            return new org.bukkit.inventory.ItemStack(bedWarsTeam.getColor().glazedTerracottaMaterial(), itemStack.getAmount());
+        } else if (type.contains("_WOOL")) {
+            return new org.bukkit.inventory.ItemStack(bedWarsTeam.getColor().woolMaterial(), itemStack.getAmount());
+        }
+        return itemStack;
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack createItemStack(String material, int amount, short data) {
+        org.bukkit.inventory.ItemStack i;
+        try {
+            i = new org.bukkit.inventory.ItemStack(org.bukkit.Material.valueOf(material), amount);
+        } catch (Exception ex) {
+            getPlugin().getLogger().log(Level.WARNING, material + " is not a valid " + getName() + " material!");
+            i = new org.bukkit.inventory.ItemStack(org.bukkit.Material.BEDROCK);
+        }
+        return i;
+    }
+
+    @Override
+    public org.bukkit.Material materialFireball() {
+        return org.bukkit.Material.FIRE_CHARGE;
+    }
+
+    @Override
+    public org.bukkit.Material materialPlayerHead() {
+        return org.bukkit.Material.PLAYER_HEAD;
+    }
+
+    @Override
+    public org.bukkit.Material materialSnowball() {
+        return org.bukkit.Material.SNOWBALL;
+    }
+
+    @Override
+    public org.bukkit.Material materialGoldenHelmet() {
+        return org.bukkit.Material.GOLDEN_HELMET;
+    }
+
+    @Override
+    public org.bukkit.Material materialGoldenChestPlate() {
+        return org.bukkit.Material.GOLDEN_CHESTPLATE;
+    }
+
+    @Override
+    public org.bukkit.Material materialGoldenLeggings() {
+        return org.bukkit.Material.GOLDEN_LEGGINGS;
+    }
+
+    @Override
+    public org.bukkit.Material materialNetheriteHelmet() {
+        return Material.NETHERITE_HELMET;
+    }
+
+    @Override
+    public org.bukkit.Material materialNetheriteChestPlate() {
+        return Material.NETHERITE_CHESTPLATE;
+    }
+
+    @Override
+    public org.bukkit.Material materialNetheriteLeggings() {
+        return Material.NETHERITE_LEGGINGS;
+    }
+
+    @Override
+    public org.bukkit.Material materialElytra() {
+        return Material.ELYTRA;
+    }
+
+    @Override
+    public org.bukkit.Material materialCake() {
+        return org.bukkit.Material.CAKE;
+    }
+
+    @Override
+    public org.bukkit.Material materialCraftingTable() {
+        return org.bukkit.Material.CRAFTING_TABLE;
+    }
+
+    @Override
+    public org.bukkit.Material materialEnchantingTable() {
+        return org.bukkit.Material.ENCHANTING_TABLE;
+    }
+
+    @Override
+    public org.bukkit.Material woolMaterial() {
+        return org.bukkit.Material.WHITE_WOOL;
+    }
+
+    @Override
+    public String getShopUpgradeIdentifier(org.bukkit.inventory.ItemStack itemStack) {
+        var tag = getCreateTag(itemStack);
+        return tag.e(VersionSupport.PLUGIN_TAG_TIER_KEY) ? tag.l(VersionSupport.PLUGIN_TAG_TIER_KEY) : "null";
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack setShopUpgradeIdentifier(org.bukkit.inventory.ItemStack itemStack, String identifier) {
+        var tag = getCreateTag(itemStack);
+        tag.a(VersionSupport.PLUGIN_TAG_TIER_KEY, identifier);
+        return applyTag(itemStack, tag);
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack getPlayerHead(Player player, org.bukkit.inventory.ItemStack copyTagFrom) {
+        org.bukkit.inventory.ItemStack head = new org.bukkit.inventory.ItemStack(materialPlayerHead());
+
+        if (copyTagFrom != null) {
+            var tag = getTag(copyTagFrom);
+            head = applyTag(head, tag);
+        }
+
+        var meta = head.getItemMeta();
+        if (meta instanceof SkullMeta) {
+            ((SkullMeta) meta).setOwnerProfile(player.getPlayerProfile());
+        }
+        head.setItemMeta(meta);
+        return head;
+    }
+
+    @Override
+    public void sendPlayerSpawnPackets(Player respawned, IArena arena) {
+        if (respawned == null) return;
+        if (arena == null) return;
+        if (!arena.isPlayer(respawned)) return;
+
+        // if method was used when the player was still in re-spawning screen
+        if (arena.getRespawnSessions().containsKey(respawned)) return;
+
+        EntityPlayer entityPlayer = getPlayer(respawned);
+        PacketPlayOutSpawnEntity show = new PacketPlayOutSpawnEntity(entityPlayer);
+        PacketPlayOutEntityVelocity playerVelocity = new PacketPlayOutEntityVelocity(entityPlayer);
+        // we send head rotation packet because sometimes on respawn others see him with bad rotation
+        PacketPlayOutEntityHeadRotation head = new PacketPlayOutEntityHeadRotation(entityPlayer, getCompressedAngle(entityPlayer.getBukkitYaw()));
+
+        // retrieve current armor and in-hand items
+        // we send a packet later for timing issues where other players do not see them
+        List<Pair<EnumItemSlot, ItemStack>> list = getPlayerEquipment(entityPlayer);
+
+
+        for (Player p : arena.getPlayers()) {
+            if (p == null) continue;
+            if (p.equals(respawned)) continue;
+            // if p is in re-spawning screen continue
+            if (arena.getRespawnSessions().containsKey(p)) continue;
+
+            EntityPlayer boundTo = getPlayer(p);
+            if (p.getWorld().equals(respawned.getWorld())) {
+                if (respawned.getLocation().distance(p.getLocation()) <= arena.getRenderDistance()) {
+
+                    // send respawned player to regular players
+                    this.sendPackets(
+                            p, show, head, playerVelocity,
+                            new PacketPlayOutEntityEquipment(respawned.getEntityId(), list)
+                    );
+
+                    // send nearby players to respawned player
+                    // if the player has invisibility hide armor
+                    if (p.hasPotionEffect(PotionEffectType.INVISIBILITY)) {
+                        hideArmor(p, respawned);
+                    } else {
+
+                        PacketPlayOutSpawnEntity show2 = new PacketPlayOutSpawnEntity(boundTo);
+                        PacketPlayOutEntityVelocity playerVelocity2 = new PacketPlayOutEntityVelocity(boundTo);
+                        PacketPlayOutEntityHeadRotation head2 = new PacketPlayOutEntityHeadRotation(boundTo, getCompressedAngle(boundTo.getBukkitYaw()));
+                        this.sendPackets(respawned, show2, playerVelocity2, head2);
+
+                        showArmor(p, respawned);
+                    }
+                }
+            }
+        }
+
+        for (Player spectator : arena.getSpectators()) {
+            if (spectator == null) continue;
+            if (spectator.equals(respawned)) continue;
+            EntityPlayer boundTo = ((CraftPlayer) spectator).getHandle();
+            respawned.hidePlayer(getPlugin(), spectator);
+            if (spectator.getWorld().equals(respawned.getWorld())) {
+                if (respawned.getLocation().distance(spectator.getLocation()) <= arena.getRenderDistance()) {
+
+                    // send respawned player to spectator
+                    this.sendPackets(
+                            spectator, show, playerVelocity,
+                            new PacketPlayOutEntityEquipment(respawned.getEntityId(), list),
+                            new PacketPlayOutEntityHeadRotation(entityPlayer, getCompressedAngle(entityPlayer.getBukkitYaw()))
+                    );
+                }
+            }
+        }
+    }
+
+    @Override
+    public String getInventoryName(@NotNull InventoryEvent e) {
+        return e.getView().getTitle();
+    }
+
+    @Override
+    public void setUnbreakable(@NotNull ItemMeta itemMeta) {
+        itemMeta.setUnbreakable(true);
+    }
+
+    @Override
+    public String getMainLevel() {
+        //noinspection deprecation
+        return ((DedicatedServer) MinecraftServer.getServer()).a().m;
+    }
+
+    @Override
+    public int getVersion() {
+        // impacts on sidebar
+        // experimental score placeholders
+        return 10;
+    }
+
+    @Override
+    public void setJoinSignBackground(@NotNull BlockState b, org.bukkit.Material material) {
+        if (b.getBlockData() instanceof WallSign) {
+            b.getBlock().getRelative(((WallSign) b.getBlockData()).getFacing().getOppositeFace()).setType(material);
+        }
+    }
+
+    @Override
+    public void spigotShowPlayer(Player victim, @NotNull Player receiver) {
+        receiver.showPlayer(getPlugin(), victim);
+    }
+
+    @Override
+    public void spigotHidePlayer(Player victim, @NotNull Player receiver) {
+        receiver.hidePlayer(getPlugin(), victim);
+    }
+
+    @Override
+    public Fireball setFireballDirection(Fireball fireball, @NotNull Vector vector) {
+        EntityFireball fb = ((CraftFireball) fireball).getHandle();
+        fb.b = vector.getX() * 0.1D;
+        fb.c = vector.getY() * 0.1D;
+        fb.d = vector.getZ() * 0.1D;
+        return (Fireball) fb.getBukkitEntity();
+    }
+
+    @Override
+    public void playRedStoneDot(@NotNull Player player) {
+        Color color = Color.RED;
+        PacketPlayOutWorldParticles particlePacket = new PacketPlayOutWorldParticles(
+                new ParticleParamRedstone(
+                        new Vector3f((float) color.getRed(),
+                                (float) color.getGreen(),
+                                (float) color.getBlue()), (float) 1
+                ),
+                true,
+                player.getLocation().getX(),
+                player.getLocation().getY() + 2.6,
+                player.getLocation().getZ(),
+                0, 0, 0, 0, 0
+        );
+        for (Player inWorld : player.getWorld().getPlayers()) {
+            if (inWorld.equals(player)) continue;
+            this.sendPacket(inWorld, particlePacket);
+        }
+    }
+
+    @Override
+    public void clearArrowsFromPlayerBody(Player player) {
+        // minecraft clears them on death on newer version
+    }
+
+    /**
+     * Gets the NMS Item from ItemStack
+     */
+    private @Nullable Item getItem(org.bukkit.inventory.ItemStack itemStack) {
+        var i = CraftItemStack.asNMSCopy(itemStack);
+        if (null == i) {
+            return null;
+        }
+        return i.d();
+    }
+
+    /**
+     * Gets the NMS Entity from ItemStack
+     */
+    private @Nullable net.minecraft.world.entity.Entity getEntity(org.bukkit.inventory.ItemStack itemStack) {
+        var i = CraftItemStack.asNMSCopy(itemStack);
+        if (null == i) {
+            return null;
+        }
+        return i.H();
+    }
+
+    private @Nullable NBTTagCompound getTag(@NotNull org.bukkit.inventory.ItemStack itemStack) {
+        var i = CraftItemStack.asNMSCopy(itemStack);
+        if (null == i) {
+            return null;
+        }
+        return i.v();
+    }
+
+    private @Nullable NBTTagCompound getTag(@NotNull ItemStack itemStack) {
+        return itemStack.v();
+    }
+
+    private @NotNull NBTTagCompound initializeTag(org.bukkit.inventory.ItemStack itemStack) {
+        var i = CraftItemStack.asNMSCopy(itemStack);
+        if (null == i) {
+            throw new RuntimeException("Cannot convert given item to a NMS item");
+        }
+        return initializeTag(i);
+    }
+
+    private @NotNull NBTTagCompound initializeTag(ItemStack itemStack) {
+
+        var tag = getTag(itemStack);
+        if (null != tag) {
+            throw new RuntimeException("Provided item already has a Tag");
+        }
+        tag = new NBTTagCompound();
+        itemStack.c(tag);
+
+        return tag;
+    }
+
+    public NBTTagCompound getCreateTag(ItemStack itemStack) {
+        var tag = getTag(itemStack);
+        return null == tag ? initializeTag(itemStack) : tag;
+    }
+
+    public NBTTagCompound getCreateTag(org.bukkit.inventory.ItemStack itemStack) {
+        var i = CraftItemStack.asNMSCopy(itemStack);
+        if (null == i) {
+            throw new RuntimeException("Cannot convert given item to a NMS item");
+        }
+        return getCreateTag(i);
+    }
+
+    public org.bukkit.inventory.ItemStack applyTag(org.bukkit.inventory.ItemStack itemStack, NBTTagCompound tag) {
+        return CraftItemStack.asBukkitCopy(applyTag(getNmsItemCopy(itemStack), tag));
+    }
+
+    public ItemStack applyTag(@NotNull ItemStack itemStack, NBTTagCompound tag) {
+        itemStack.c(tag);
+        return itemStack;
+    }
+
+    public ItemStack getNmsItemCopy(org.bukkit.inventory.ItemStack itemStack) {
+        ItemStack i = CraftItemStack.asNMSCopy(itemStack);
+        if (null == i) {
+            throw new RuntimeException("Cannot convert given item to a NMS item");
+        }
+        return i;
+    }
+
+    public EntityPlayer getPlayer(Player player) {
+        return ((CraftPlayer) player).getHandle();
+    }
+
+    public List<Pair<EnumItemSlot, ItemStack>> getPlayerEquipment(@NotNull Player player) {
+        return getPlayerEquipment(getPlayer(player));
+    }
+
+    public List<Pair<EnumItemSlot, ItemStack>> getPlayerEquipment(@NotNull EntityPlayer entityPlayer) {
+        List<Pair<EnumItemSlot, ItemStack>> list = new ArrayList<>();
+        list.add(new Pair<>(EnumItemSlot.a, entityPlayer.c(EnumItemSlot.a)));
+        list.add(new Pair<>(EnumItemSlot.b, entityPlayer.c(EnumItemSlot.b)));
+        list.add(new Pair<>(EnumItemSlot.f, entityPlayer.c(EnumItemSlot.f)));
+        list.add(new Pair<>(EnumItemSlot.e, entityPlayer.c(EnumItemSlot.e)));
+        list.add(new Pair<>(EnumItemSlot.d, entityPlayer.c(EnumItemSlot.d)));
+        list.add(new Pair<>(EnumItemSlot.c, entityPlayer.c(EnumItemSlot.c)));
+
+        return list;
+    }
+
+    @Override
+    public void placeTowerBlocks(@NotNull Block b, @NotNull IArena a, @NotNull TeamColor color, int x, int y, int z) {
+        b.getRelative(x, y, z).setType(color.woolMaterial());
+        a.addPlacedBlock(b.getRelative(x, y, z));
+    }
+
+    @Override
+    public void placeLadder(@NotNull Block b, int x, int y, int z, @NotNull IArena a, int ladderData) {
+        Block block = b.getRelative(x, y, z);  //ladder block
+        block.setType(Material.LADDER);
+        Ladder ladder = (Ladder) block.getBlockData();
+        a.addPlacedBlock(block);
+        switch (ladderData) {
+            case 2 -> {
+                ladder.setFacing(BlockFace.NORTH);
+                block.setBlockData(ladder);
+            }
+            case 3 -> {
+                ladder.setFacing(BlockFace.SOUTH);
+                block.setBlockData(ladder);
+            }
+            case 4 -> {
+                ladder.setFacing(BlockFace.WEST);
+                block.setBlockData(ladder);
+            }
+            case 5 -> {
+                ladder.setFacing(BlockFace.EAST);
+                block.setBlockData(ladder);
+            }
+        }
+    }
+
+    @Override
+    public void playVillagerEffect(@NotNull Player player, Location location) {
+        player.spawnParticle(Particle.VILLAGER_HAPPY, location, 1);
+    }
+
+    private void sendPacket(Player player, Packet<?> packet) {
+        ((CraftPlayer) player).getHandle().c.a(packet);
+    }
+
+    private void sendPackets(Player player, Packet<?> @NotNull ... packets) {
+        PlayerConnection connection = ((CraftPlayer) player).getHandle().c;
+        for (Packet<?> p : packets) {
+            connection.a(p);
+        }
+    }
+}


### PR DESCRIPTION
- remove scoreboard numbers, replace with team status when applicable on 1.20.3 scoreboard
- fix bStats track id 
- downgrade support to java 17 
- add 1.20.3 support
- fix metric tracking
- fix default blast protection from fireballs on 1.8.8
- add deprecation notice for 1.8.8, 1.17.1, 1.19.1 and 1.20 