### PR TITLE
Fixed tag apply

### DIFF
--- a/bedwars-plugin/pom.xml
+++ b/bedwars-plugin/pom.xml
@@ -199,6 +199,11 @@
         </dependency>
         <dependency>
             <groupId>com.andrei1058.bedwars</groupId>
+            <artifactId>versionsupport_v1_20_R4</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.andrei1058.bedwars</groupId>
             <artifactId>versionsupport-common</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -312,6 +317,12 @@
         <dependency>
             <groupId>com.andrei1058.spigot.sidebar</groupId>
             <artifactId>sidebar-v1_20_R3</artifactId>
+            <version>23.12</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.andrei1058.spigot.sidebar</groupId>
+            <artifactId>sidebar-v1_20_R4</artifactId>
             <version>23.12</version>
             <scope>compile</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,7 @@
         <module>versionsupport_v1_20_R1</module>
         <module>versionsupport_v1_20_R2</module>
         <module>versionsupport_v1_20_R3</module>
+        <module>versionsupport_v1_20_R4</module>
     </modules>
 
     <distributionManagement>

--- a/versionsupport_1_12_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_12_R1/v1_12_R1.java
+++ b/versionsupport_1_12_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_12_R1/v1_12_R1.java
@@ -377,10 +377,10 @@ public class v1_12_R1 extends VersionSupport {
         NBTTagCompound tag = itemStack.getTag();
         if (tag == null) {
             tag = new NBTTagCompound();
-            itemStack.setTag(tag);
         }
 
         tag.setString("BedWars1058", data);
+        itemStack.setTag(tag);
         return CraftItemStack.asBukkitCopy(itemStack);
     }
 
@@ -390,10 +390,10 @@ public class v1_12_R1 extends VersionSupport {
         NBTTagCompound tag = itemStack.getTag();
         if (tag == null) {
             tag = new NBTTagCompound();
-            itemStack.setTag(tag);
         }
 
         tag.setString(key, value);
+        itemStack.setTag(tag);
         return CraftItemStack.asBukkitCopy(itemStack);
     }
 

--- a/versionsupport_1_8_R3/src/main/java/com/andrei1058/bedwars/support/version/v1_8_R3/v1_8_R3.java
+++ b/versionsupport_1_8_R3/src/main/java/com/andrei1058/bedwars/support/version/v1_8_R3/v1_8_R3.java
@@ -418,10 +418,10 @@ public class v1_8_R3 extends VersionSupport {
         NBTTagCompound tag = itemStack.getTag();
         if (tag == null) {
             tag = new NBTTagCompound();
-            itemStack.setTag(tag);
         }
 
         tag.setString("BedWars1058", data);
+        itemStack.setTag(tag);
         return CraftItemStack.asBukkitCopy(itemStack);
     }
 
@@ -431,10 +431,10 @@ public class v1_8_R3 extends VersionSupport {
         NBTTagCompound tag = is.getTag();
         if (tag == null) {
             tag = new NBTTagCompound();
-            is.setTag(tag);
         }
 
         tag.setString(key, value);
+        is.setTag(tag);
         return CraftItemStack.asBukkitCopy(is);
     }
 

--- a/versionsupport_v1_16_R3/src/main/java/com/andrei1058/bedwars/support/version/v1_16_R3/v1_16_R3.java
+++ b/versionsupport_v1_16_R3/src/main/java/com/andrei1058/bedwars/support/version/v1_16_R3/v1_16_R3.java
@@ -381,10 +381,10 @@ public class v1_16_R3 extends VersionSupport {
         NBTTagCompound tag = itemStack.getTag();
         if (tag == null) {
             tag = new NBTTagCompound();
-            itemStack.setTag(tag);
         }
 
         tag.setString("BedWars1058", data);
+        itemStack.setTag(tag);
         return CraftItemStack.asBukkitCopy(itemStack);
     }
 
@@ -394,10 +394,10 @@ public class v1_16_R3 extends VersionSupport {
         NBTTagCompound tag = is.getTag();
         if (tag == null) {
             tag = new NBTTagCompound();
-            is.setTag(tag);
         }
 
         tag.setString(key, value);
+        is.setTag(tag);
         return CraftItemStack.asBukkitCopy(is);
     }
 

--- a/versionsupport_v1_17_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_17_R1/v1_17_R1.java
+++ b/versionsupport_v1_17_R1/src/main/java/com/andrei1058/bedwars/support/version/v1_17_R1/v1_17_R1.java
@@ -411,10 +411,10 @@ public class v1_17_R1 extends VersionSupport {
         NBTTagCompound tag = itemStack.getTag();
         if (tag == null) {
             tag = new NBTTagCompound();
-            itemStack.setTag(tag);
         }
 
         tag.setString("BedWars1058", data);
+        itemStack.setTag(tag);
         return CraftItemStack.asBukkitCopy(itemStack);
     }
 
@@ -424,10 +424,10 @@ public class v1_17_R1 extends VersionSupport {
         NBTTagCompound tag = is.getTag();
         if (tag == null) {
             tag = new NBTTagCompound();
-            is.setTag(tag);
         }
 
         tag.setString(key, value);
+        is.setTag(tag);
         return CraftItemStack.asBukkitCopy(is);
     }
 

--- a/versionsupport_v1_18_R2/src/main/java/com/andrei1058/bedwars/support/version/v1_18_R2/v1_18_R2.java
+++ b/versionsupport_v1_18_R2/src/main/java/com/andrei1058/bedwars/support/version/v1_18_R2/v1_18_R2.java
@@ -391,10 +391,10 @@ public class v1_18_R2 extends VersionSupport {
         NBTTagCompound tag = itemStack.t();
         if (tag == null) {
             tag = new NBTTagCompound();
-            itemStack.c(tag);
         }
 
         tag.a("BedWars1058", data);
+        itemStack.c(tag);
         return CraftItemStack.asBukkitCopy(itemStack);
     }
 
@@ -404,10 +404,10 @@ public class v1_18_R2 extends VersionSupport {
         NBTTagCompound tag = is.t();
         if (tag == null) {
             tag = new NBTTagCompound();
-            is.c(tag);
         }
 
         tag.a(key, value);
+        is.c(tag);
         return CraftItemStack.asBukkitCopy(is);
     }
 

--- a/versionsupport_v1_20_R4/pom.xml
+++ b/versionsupport_v1_20_R4/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" >
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.andrei1058.bedwars</groupId>
+        <artifactId>BedWars1058</artifactId>
+        <version>23.12.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>versionsupport_v1_20_R4</artifactId>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.andrei1058.bedwars</groupId>
+            <artifactId>versionsupport_v1_20_R3</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.andrei1058.bedwars</groupId>
+            <artifactId>bedwars-api</artifactId>
+            <version>${project.version}</version>
+            <type>jar</type>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.andrei1058.bedwars</groupId>
+            <artifactId>versionsupport-common</artifactId>
+            <version>${project.version}</version>
+            <type>jar</type>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot</artifactId>
+            <version>1.20.4-R0.1-SNAPSHOT</version>
+            <type>jar</type>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/versionsupport_v1_20_R4/src/main/java/com/andrei1058/bedwars/support/version/v1_20_R4/v1_20_R4.java
+++ b/versionsupport_v1_20_R4/src/main/java/com/andrei1058/bedwars/support/version/v1_20_R4/v1_20_R4.java
@@ -1,0 +1,12 @@
+package com.andrei1058.bedwars.support.version.v1_20_R4;
+
+import com.andrei1058.bedwars.support.version.v1_20_R3.v1_20_R3;
+import org.bukkit.plugin.Plugin;
+
+@SuppressWarnings("unused")
+public class v1_20_R4 extends v1_20_R3 {
+
+    public v1_20_R4(Plugin plugin, String name) {
+        super(plugin, name);
+    }
+}


### PR DESCRIPTION
Fixed tag apply for 1.18.2, 1.17.1, 1.12.2 and 1.8.8 where the tag wouldnt get applied ever (because the NBTTag was getting applied only if the item was null with no additive tags)