### PR TITLE
Pull Request: G25 Release and Minecraft 1.20.5 Support

### DIFF
--- a/bedwars-api/pom.xml
+++ b/bedwars-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>BedWars1058</artifactId>
         <groupId>com.andrei1058.bedwars</groupId>
-        <version>25.2</version>
+        <version>G25</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>bedwars-api</artifactId>
@@ -20,10 +20,7 @@
             <id>commons-repo</id>
             <url>https://repo.fusesource.com/nexus/content/repositories/releases-3rd-party/</url>
         </repository>
-        <repository>
-            <id>andrei-prod</id>
-            <url>https://repo.andrei1058.dev/releases</url>
-        </repository>
+        <!-- Rimossa la repo offline andrei-prod temporaneamente -->
     </repositories>
 
     <dependencies>
@@ -50,7 +47,7 @@
         <dependency>
             <groupId>com.andrei1058.spigot.sidebar</groupId>
             <artifactId>sidebar-base</artifactId>
-            <version>23.2</version>
+            <version>24</version>
         </dependency>
     </dependencies>
     <build>

--- a/bedwars-api/src/main/java/com/andrei1058/bedwars/api/configuration/ConfigPath.java
+++ b/bedwars-api/src/main/java/com/andrei1058/bedwars/api/configuration/ConfigPath.java
@@ -29,6 +29,14 @@ public class ConfigPath {
     @GameMainOverridable
     public static final String GENERAL_GAME_END_TELEPORT_ELIMINATED = GAME_END_PATH+".teleport-eliminated";
     @GameMainOverridable
+    public static final String GENERAL_GAME_END_FORCE_SPECTATOR_BEFORE_LOBBY = GAME_END_PATH + ".force-spectator-before-lobby";
+    @GameMainOverridable
+    public static final String GENERAL_GAME_END_FORCE_SPECTATOR_GAMEMODE = GAME_END_PATH + ".force-spectator-gamemode";
+    @GameMainOverridable
+    public static final String GENERAL_GAME_END_CLEAR_CHAT_BEFORE_ANNOUNCEMENT = GAME_END_PATH + ".clear-chat-before-announcement";
+    @GameMainOverridable
+    public static final String GENERAL_GAME_END_CLEAR_CHAT_LINES = GAME_END_PATH + ".clear-chat-lines";
+    @GameMainOverridable
     public static final String GENERAL_GAME_END_CHAT_TOP_STATISTIC = GAME_END_PATH+".chat-top.order-by";
     @GameMainOverridable
     public static final String GENERAL_GAME_END_CHAT_TOP_HIDE_MISSING = GAME_END_PATH+".chat-top.hide-missing";
@@ -117,6 +125,18 @@ public class ConfigPath {
     public static final String GENERAL_CONFIGURATION_PRE_GAME_ITEMS_SLOT = GENERAL_CONFIGURATION_PRE_GAME_ITEMS_PATH + ".%path%.slot";
     public static final String GENERAL_CONFIGURATION_PRE_GAME_ITEMS_ENCHANTED = GENERAL_CONFIGURATION_PRE_GAME_ITEMS_PATH + ".%path%.enchanted";
     public static final String GENERAL_CONFIGURATION_PRE_GAME_ITEMS_COMMAND = GENERAL_CONFIGURATION_PRE_GAME_ITEMS_PATH + ".%path%.command";
+
+    private static final String GENERAL_CONFIGURATION_PLAYER_GAMEMODE_PATH = "player-gamemode";
+    public static final String GENERAL_CONFIGURATION_PLAYER_GAMEMODE_IN_GAME = GENERAL_CONFIGURATION_PLAYER_GAMEMODE_PATH + ".in-game";
+    public static final String GENERAL_CONFIGURATION_PLAYER_GAMEMODE_LOBBY = GENERAL_CONFIGURATION_PLAYER_GAMEMODE_PATH + ".lobby";
+
+    private static final String GENERAL_CONFIGURATION_SPECTATOR_SETTINGS_PATH = "spectator-settings";
+    public static final String GENERAL_CONFIGURATION_SPECTATOR_GAMEMODE = GENERAL_CONFIGURATION_SPECTATOR_SETTINGS_PATH + ".gamemode";
+    public static final String GENERAL_CONFIGURATION_SPECTATOR_TRANSPARENCY = GENERAL_CONFIGURATION_SPECTATOR_SETTINGS_PATH + ".transparency";
+    private static final String GENERAL_CONFIGURATION_SPECTATOR_TAB_PATH = GENERAL_CONFIGURATION_SPECTATOR_SETTINGS_PATH + ".tab";
+    public static final String GENERAL_CONFIGURATION_SPECTATOR_TAB_SPECTATORS_SEE_PLAYERS = GENERAL_CONFIGURATION_SPECTATOR_TAB_PATH + ".spectators-see-players";
+    public static final String GENERAL_CONFIGURATION_SPECTATOR_TAB_SPECTATORS_SEE_SPECTATORS = GENERAL_CONFIGURATION_SPECTATOR_TAB_PATH + ".spectators-see-spectators";
+    public static final String GENERAL_CONFIGURATION_SPECTATOR_TAB_PLAYERS_SEE_SPECTATORS = GENERAL_CONFIGURATION_SPECTATOR_TAB_PATH + ".players-see-spectators";
 
     public static final String GENERAL_CONFIGURATION_START_COUNTDOWN_REGULAR = "countdowns.game-start-regular";
     public static final String GENERAL_CONFIGURATION_START_COUNTDOWN_SHORTENED = "countdowns.game-start-shortened";

--- a/bedwars-api/src/main/java/com/andrei1058/bedwars/api/configuration/ConfigPath.java
+++ b/bedwars-api/src/main/java/com/andrei1058/bedwars/api/configuration/ConfigPath.java
@@ -173,6 +173,15 @@ public class ConfigPath {
     public static final String GENERAL_CONFIGURATION_DISABLE_ANVIL = "inventories.disable-anvil";
     public static final String GENERAL_CONFIGURATION_MARK_LEAVE_AS_ABANDON = "mark-leave-as-abandon";
     public static final String GENERAL_CONFIGURATION_ENABLE_GEN_SPLIT = "enable-gen-split";
+    public static final String GENERAL_CONFIGURATION_GEN_SPLIT_RADIUS = "gen-split-radius";
+    // MOD G25.2 - Quick Deposit: trasferisce le valute (ferro/oro/diamanti/smeraldi)
+    // dall'inventario del player alla cassa del suo team con Shift+Click destro
+    public static final String GENERAL_CONFIGURATION_ENABLE_QUICK_DEPOSIT = "enable-quick-deposit";
+
+    // MOD G25.2 - Invisibilita': flag per sopprimere suoni/particelle dei giocatori invisibili
+    public static final String INVISIBILITY_SUPPRESS_FOOTSTEPS = "invisibility.suppress-footstep-sounds";
+    public static final String INVISIBILITY_SUPPRESS_PARTICLES = "invisibility.suppress-particles";
+    public static final String INVISIBILITY_TEAM_CAN_SEE_ARMOR = "invisibility.team-can-see-armor";
 
     public static final String GENERAL_CONFIG_PLACEHOLDERS_REPLACEMENTS_SERVER_IP = "server-ip";
     public static final String GENERAL_CONFIG_PLACEHOLDERS_REPLACEMENTS_POWERED_BY = "powered-by";
@@ -239,6 +248,12 @@ public class ConfigPath {
     public static final String GENERAL_TNT_PRIME = "tnt-prime-settings";
     public static final String GENERAL_TNT_AUTO_IGNITE = GENERAL_TNT_PRIME+".auto-ignite";
     public static final String GENERAL_TNT_FUSE_TICKS = GENERAL_TNT_PRIME+".fuse-ticks";
+    private static final String GENERAL_TNT_COUNTDOWN = GENERAL_TNT_PRIME + ".countdown";
+    public static final String GENERAL_TNT_COUNTDOWN_ENABLED = GENERAL_TNT_COUNTDOWN + ".enabled";
+    public static final String GENERAL_TNT_COUNTDOWN_NAME_VISIBLE = GENERAL_TNT_COUNTDOWN + ".name-visible";
+    public static final String GENERAL_TNT_COUNTDOWN_FORMAT = GENERAL_TNT_COUNTDOWN + ".format";
+    public static final String GENERAL_TNT_COUNTDOWN_DECIMALS = GENERAL_TNT_COUNTDOWN + ".seconds-decimals";
+    public static final String GENERAL_TNT_COUNTDOWN_UPDATE_INTERVAL = GENERAL_TNT_COUNTDOWN + ".update-interval-ticks";
 
     private static final String GENERAL_FIREBALL_PATH = "fireball";
     public static final String GENERAL_FIREBALL_EXPLOSION_SIZE = GENERAL_FIREBALL_PATH + ".explosion-size";

--- a/bedwars-plugin/pom.xml
+++ b/bedwars-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>BedWars1058</artifactId>
         <groupId>com.andrei1058.bedwars</groupId>
-        <version>25.2</version>
+        <version>G25</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>bedwars-plugin</artifactId>
@@ -50,13 +50,14 @@
             <id>alessioDP-releases</id>
             <url>https://repo.alessiodp.com/releases/</url>
         </repository>
-        <repository>
-            <id>andrei1058-releases</id>
-            <url>https://repo.andrei1058.dev/releases/</url>
-        </repository>
+        <!-- Rimosso repo offline andrei1058 temporaneamente -->
         <repository>
             <id>citizens-repo</id>
             <url>https://maven.citizensnpcs.co/repo</url>
+        </repository>
+        <repository>
+            <id>dmulloy2-repo</id>
+            <url>https://repo.dmulloy2.net/repository/public/</url>
         </repository>
         <repository>
             <id>papermc</id>
@@ -88,6 +89,18 @@
             <artifactId>bstats-bukkit</artifactId>
             <version>3.0.2</version>
             <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.bstats</groupId>
+            <artifactId>bstats-base</artifactId>
+            <version>3.0.2</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.comphenix.protocol</groupId>
+            <artifactId>ProtocolLib</artifactId>
+            <version>5.3.0</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>de.simonsator</groupId>
@@ -249,85 +262,85 @@
         <dependency>
             <groupId>com.andrei1058.spigot.sidebar</groupId>
             <artifactId>sidebar-base</artifactId>
-            <version>24.2</version>
+            <version>24</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.andrei1058.spigot.sidebar</groupId>
             <artifactId>sidebar-v1_8_R3</artifactId>
-            <version>24.2</version>
+            <version>24</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.andrei1058.spigot.sidebar</groupId>
             <artifactId>sidebar-v1_12_R1</artifactId>
-            <version>24.2</version>
+            <version>24</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.andrei1058.spigot.sidebar</groupId>
             <artifactId>sidebar-v1_16_R3</artifactId>
-            <version>24.2</version>
+            <version>24</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.andrei1058.spigot.sidebar</groupId>
             <artifactId>sidebar-v1_17_R1</artifactId>
-            <version>24.2</version>
+            <version>24</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.andrei1058.spigot.sidebar</groupId>
             <artifactId>sidebar-v1_18_R2</artifactId>
-            <version>24.2</version>
+            <version>24</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.andrei1058.spigot.sidebar</groupId>
             <artifactId>sidebar-v1_19_R2</artifactId>
-            <version>24.2</version>
+            <version>24</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.andrei1058.spigot.sidebar</groupId>
             <artifactId>sidebar-v1_19_R3</artifactId>
-            <version>24.2</version>
+            <version>24</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.andrei1058.spigot.sidebar</groupId>
             <artifactId>sidebar-v1_20_R1</artifactId>
-            <version>24.2</version>
+            <version>24</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.andrei1058.spigot.sidebar</groupId>
             <artifactId>sidebar-v1_20_R2</artifactId>
-            <version>24.2</version>
+            <version>24</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.andrei1058.spigot.sidebar</groupId>
             <artifactId>sidebar-v1_20_R3</artifactId>
-            <version>24.2</version>
+            <version>24</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.andrei1058.spigot.sidebar</groupId>
             <artifactId>sidebar-v1_20_R4</artifactId>
-            <version>24.2</version>
+            <version>24</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.andrei1058.spigot.sidebar</groupId>
             <artifactId>sidebar-v1_20_R4</artifactId>
-            <version>23.12</version>
+            <version>24</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.andrei1058.spigot.sidebar</groupId>
             <artifactId>sidebar-v1_20_R4</artifactId>
-            <version>23.12</version>
+            <version>24</version>
             <scope>compile</scope>
         </dependency>
         <!--        End of Sidebar LIB-->

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/BedWars.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/BedWars.java
@@ -312,7 +312,14 @@ public class BedWars extends JavaPlugin {
         // Register setup-holograms fix
         registerEvents(new ChunkLoad());
 
+        // MOD 08/04/2026: Aggiunto InvisibilityFootstepsFix listener
+        InvisibilityPacketListener.register(this);
         registerEvents(new InvisibilityPotionListener());
+
+        // MOD 08/04/2026: Quick Deposit (Shift+Click destro su cassa team -> deposita valute)
+        if (config.getBoolean(ConfigPath.GENERAL_CONFIGURATION_ENABLE_QUICK_DEPOSIT)) {
+            registerEvents(new QuickDepositListener());
+        }
 
         /* Load join signs. */
         loadArenasAndSigns();

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/Arena.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/Arena.java
@@ -546,6 +546,7 @@ public class Arena implements IArena {
                 new PlayerGoods(p, true);
                 playerLocation.put(p, p.getLocation());
             }
+            p.setGameMode(getConfiguredGameMode(ConfigPath.GENERAL_CONFIGURATION_PLAYER_GAMEMODE_IN_GAME, GameMode.SURVIVAL));
             TeleportManager.teleportC(p, getWaitingLocation(), PlayerTeleportEvent.TeleportCause.PLUGIN);
 
             if (!isStatusChange) {
@@ -659,7 +660,7 @@ public class Arena implements IArena {
                 }
             }
 
-            p.setGameMode(GameMode.ADVENTURE);
+            p.setGameMode(getConfiguredGameMode(ConfigPath.GENERAL_CONFIGURATION_SPECTATOR_GAMEMODE, GameMode.ADVENTURE));
 
             Bukkit.getScheduler().runTaskLater(plugin, () -> {
                 if (leaving.contains(p)) return;
@@ -672,14 +673,30 @@ public class Arena implements IArena {
 
             Bukkit.getScheduler().runTask(plugin, () -> {
                 if (leaving.contains(p)) return;
+                boolean spectatorsSeePlayers = config.getBoolean(ConfigPath.GENERAL_CONFIGURATION_SPECTATOR_TAB_SPECTATORS_SEE_PLAYERS);
+                boolean spectatorsSeeSpectators = config.getBoolean(ConfigPath.GENERAL_CONFIGURATION_SPECTATOR_TAB_SPECTATORS_SEE_SPECTATORS);
+                boolean playersSeeSpectators = config.getBoolean(ConfigPath.GENERAL_CONFIGURATION_SPECTATOR_TAB_PLAYERS_SEE_SPECTATORS);
                 for (Player on : Bukkit.getOnlinePlayers()) {
                     if (on == p) continue;
                     if (getSpectators().contains(on)) {
-                        BedWars.nms.spigotShowPlayer(p, on);
-                        BedWars.nms.spigotShowPlayer(on, p);
+                        if (spectatorsSeeSpectators) {
+                            BedWars.nms.spigotShowPlayer(p, on);
+                            BedWars.nms.spigotShowPlayer(on, p);
+                        } else {
+                            BedWars.nms.spigotHidePlayer(p, on);
+                            BedWars.nms.spigotHidePlayer(on, p);
+                        }
                     } else if (getPlayers().contains(on)) {
-                        BedWars.nms.spigotHidePlayer(p, on);
-                        BedWars.nms.spigotShowPlayer(on, p);
+                        if (spectatorsSeePlayers) {
+                            BedWars.nms.spigotShowPlayer(p, on);
+                        } else {
+                            BedWars.nms.spigotHidePlayer(p, on);
+                        }
+                        if (playersSeeSpectators) {
+                            BedWars.nms.spigotShowPlayer(on, p);
+                        } else {
+                            BedWars.nms.spigotHidePlayer(on, p);
+                        }
                     } else {
                         BedWars.nms.spigotHidePlayer(p, on);
                         BedWars.nms.spigotHidePlayer(on, p);
@@ -702,8 +719,12 @@ public class Arena implements IArena {
 
                 /* Spectator items */
                 sendSpectatorCommandItems(p);
-                // make invisible because it is annoying whene there are many spectators around the map
-                p.addPotionEffect(new PotionEffect(PotionEffectType.INVISIBILITY, Integer.MAX_VALUE, 1, false));
+                // apply transparency based on config
+                if (config.getBoolean(ConfigPath.GENERAL_CONFIGURATION_SPECTATOR_TRANSPARENCY)) {
+                    p.addPotionEffect(new PotionEffect(PotionEffectType.INVISIBILITY, Integer.MAX_VALUE, 1, false));
+                } else {
+                    p.removePotionEffect(PotionEffectType.INVISIBILITY);
+                }
 
                 p.getInventory().setArmorContents(null);
             });
@@ -1911,6 +1932,12 @@ public class Arena implements IArena {
                     List<Player> receivers = new ArrayList<>(getPlayers().size() + getSpectators().size());
                     receivers.addAll(getPlayers());
                     receivers.addAll(getSpectators());
+                    
+                    if (getConfig().getGameOverridableBoolean(ConfigPath.GENERAL_GAME_END_CLEAR_CHAT_BEFORE_ANNOUNCEMENT)) {
+                        clearChat(receivers, getConfig().getGameOverridableValue(ConfigPath.GENERAL_GAME_END_CLEAR_CHAT_LINES) instanceof Number
+                                ? ((Number) getConfig().getGameOverridableValue(ConfigPath.GENERAL_GAME_END_CLEAR_CHAT_LINES)).intValue()
+                                : 120);
+                    }
 
                     if (null != topInChat) {
                         StatisticsOrdered.StringParser statParser = topInChat.newParser();
@@ -2663,6 +2690,7 @@ public class Arena implements IArena {
      * Contains fall-backs.
      */
     private void sendToMainLobby(Player player) {
+        player.setGameMode(getConfiguredGameMode(ConfigPath.GENERAL_CONFIGURATION_PLAYER_GAMEMODE_LOBBY, GameMode.SURVIVAL));
         if (BedWars.getServerType() == ServerType.SHARED) {
             Location loc = playerLocation.get(player);
             if (loc == null) {
@@ -2677,6 +2705,27 @@ public class Arena implements IArena {
                 plugin.getLogger().log(Level.SEVERE, player.getName() + " was teleported to the main world because lobby location is not set!");
             } else {
                 TeleportManager.teleportC(player, config.getConfigLoc("lobbyLoc"), PlayerTeleportEvent.TeleportCause.PLUGIN);
+            }
+        }
+    }
+
+    public static GameMode getConfiguredGameMode(String path, GameMode fallback) {
+        String raw = config.getString(path);
+        if (raw == null || raw.trim().isEmpty()) {
+            return fallback;
+        }
+        try {
+            return GameMode.valueOf(raw.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException ignored) {
+            return fallback;
+        }
+    }
+
+    private void clearChat(@NotNull Collection<Player> players, int lines) {
+        int safeLines = Math.max(0, lines);
+        for (Player player : players) {
+            for (int i = 0; i < safeLines; i++) {
+                player.sendMessage("");
             }
         }
     }

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/Arena.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/Arena.java
@@ -45,6 +45,7 @@ import com.andrei1058.bedwars.api.events.server.ArenaEnableEvent;
 import com.andrei1058.bedwars.api.events.server.ArenaRestartEvent;
 import com.andrei1058.bedwars.api.language.Language;
 import com.andrei1058.bedwars.api.language.Messages;
+import com.andrei1058.bedwars.listeners.InvisibilityPotionListener;
 import com.andrei1058.bedwars.api.region.Region;
 import com.andrei1058.bedwars.api.server.ServerType;
 import com.andrei1058.bedwars.api.sidebar.ISidebar;
@@ -1313,7 +1314,7 @@ public class Arena implements IArena {
      */
     @Override
     public List<Player> getPlayers() {
-        return players;
+        return players == null ? Collections.emptyList() : players;
     }
 
     /**
@@ -1573,7 +1574,7 @@ public class Arena implements IArena {
      */
     @Override
     public boolean isPlayer(Player p) {
-        return players.contains(p);
+        return players != null && players.contains(p);
     }
 
     /**
@@ -1581,7 +1582,7 @@ public class Arena implements IArena {
      */
     @Override
     public boolean isSpectator(Player p) {
-        return spectators.contains(p);
+        return spectators != null && spectators.contains(p);
     }
 
     @Override
@@ -1657,7 +1658,7 @@ public class Arena implements IArena {
      */
     @Override
     public List<Player> getSpectators() {
-        return spectators;
+        return spectators == null ? Collections.emptyList() : spectators;
     }
 
     /**
@@ -2519,7 +2520,9 @@ public class Arena implements IArena {
                     nms.setCollide(player, this, false);
                     // #274
                     for (Player invisible : getShowTime().keySet()) {
-                        BedWars.nms.hideArmor(invisible, player);
+                        if (InvisibilityPotionListener.shouldHideArmorForViewer(this, invisible, player)) {
+                            BedWars.nms.hideArmor(invisible, player);
+                        }
                     }
 
                     updateSpectatorCollideRule(player, false);

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/OreGenerator.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/OreGenerator.java
@@ -44,7 +44,9 @@ import org.bukkit.util.Vector;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.stream.Collectors;
 
 import static com.andrei1058.bedwars.BedWars.*;
 
@@ -173,20 +175,48 @@ public class OreGenerator implements IGenerator {
                 return;
             }
             if (plugin.getConfig().getBoolean(ConfigPath.GENERAL_CONFIGURATION_ENABLE_GEN_SPLIT)) {
-                Object[] players = location.getWorld().getNearbyEntities(location, 1, 1, 1).stream().filter(entity -> entity.getType() == EntityType.PLAYER)
-                        .filter(entity -> arena.isPlayer((Player) entity)).toArray();
-                if (players.length <= 1) {
+                // MOD [DEBUG] FASE 1 - Gen Split: distribuisce a tutti i player VICINI al generatore
+                // Raggio configurabile con gen-split-radius in config.yml
+                double radius = plugin.getConfig().getDouble(ConfigPath.GENERAL_CONFIGURATION_GEN_SPLIT_RADIUS, 1.5);
+
+                // Trova tutti i player del team nel raggio (anche 1 solo basta)
+                List<Player> nearbyMembers = bwt.getMembers().stream()
+                        .filter(p -> p.getLocation().distanceSquared(location) <= radius * radius)
+                        .collect(Collectors.toList());
+
+                if (nearbyMembers.isEmpty()) {
+                    // Nessuno vicino: drop normale a terra
                     dropItem(location);
                     return;
                 }
-                for (Object o : players) {
-                    Player player = (Player) o;
-                    ItemStack item = ore.clone();
-                    item.setAmount(amount);
-                    player.playSound(player.getLocation(), Sound.valueOf(BedWars.getForCurrentVersion("ITEM_PICKUP", "ENTITY_ITEM_PICKUP", "ENTITY_ITEM_PICKUP")), 0.6f, 1.3f);
-                    Collection<ItemStack> excess = player.getInventory().addItem(item).values();
+
+                // Ogni player vicino riceve il proprio item direttamente nell'inventario
+                // con un'entità visiva che vola dal generatore verso il player.
+                for (Player member : nearbyMembers) {
+                    ItemStack teamItem = ore.clone();
+                    teamItem.setAmount(amount);
+
+                    // Animazione: spawna un'entità item al generatore con velocità verso il player.
+                    // setPickupDelay alto → nessuno può raccoglierla; rimossa dopo 15 tick.
+                    Location spawnLoc = location.clone().add(0, 0.3, 0);
+                    Item visual = location.getWorld().dropItem(spawnLoc, teamItem.clone());
+                    visual.setPickupDelay(32767);
+                    Vector dir = member.getLocation().add(0, 0.8, 0).toVector()
+                            .subtract(spawnLoc.toVector());
+                    double dist = dir.length();
+                    if (dist > 0.1) {
+                        dir.normalize().multiply(Math.min(dist * 0.14, 0.55));
+                        dir.setY(dir.getY() + 0.12);
+                    }
+                    visual.setVelocity(dir);
+                    Bukkit.getScheduler().runTaskLater(plugin, () -> {
+                        if (!visual.isDead()) visual.remove();
+                    }, 15L);
+
+                    member.playSound(member.getLocation(), Sound.valueOf(BedWars.getForCurrentVersion("ITEM_PICKUP", "ENTITY_ITEM_PICKUP", "ENTITY_ITEM_PICKUP")), 0.6f, 1.3f);
+                    Collection<ItemStack> excess = member.getInventory().addItem(teamItem).values();
                     for (ItemStack value : excess) {
-                        dropItem(player.getLocation(), value.getAmount());
+                        dropItem(member.getLocation(), value.getAmount());
                     }
                 }
                 return;

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/PlayerGoods.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/PlayerGoods.java
@@ -21,6 +21,7 @@
 package com.andrei1058.bedwars.arena;
 
 import com.andrei1058.bedwars.BedWars;
+import com.andrei1058.bedwars.api.configuration.ConfigPath;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
@@ -110,7 +111,7 @@ class PlayerGoods {
             if (!rejoin) {
                 p.getEnderChest().clear();
             }
-            p.setGameMode(GameMode.SURVIVAL);
+            p.setGameMode(Arena.getConfiguredGameMode(ConfigPath.GENERAL_CONFIGURATION_PLAYER_GAMEMODE_IN_GAME, GameMode.SURVIVAL));
             p.setAllowFlight(false);
             p.setFlying(false);
 

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/PlayerGoods.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/PlayerGoods.java
@@ -113,6 +113,16 @@ class PlayerGoods {
             p.setGameMode(GameMode.SURVIVAL);
             p.setAllowFlight(false);
             p.setFlying(false);
+
+            // MOD G25.2 [DEBUG] FASE 1 - Ripristina la barra XP BedWars dopo il reset di PlayerGoods.
+            // PlayerGoods cancella exp/level vanilla per preparare l'arena, ma la barra BedWars
+            // deve rimanere visibile anche nella fase 'waiting' (prima dell'inizio partita).
+            Bukkit.getScheduler().runTaskLater(plugin, () -> {
+                if (!p.isOnline()) return;
+                com.andrei1058.bedwars.levels.internal.PlayerLevel pl =
+                        com.andrei1058.bedwars.levels.internal.PlayerLevel.getLevelByPlayer(p.getUniqueId());
+                if (pl != null) pl.updateXpBar(p);
+            }, 2L);
         }
     }
 

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/ReJoin.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/ReJoin.java
@@ -149,7 +149,7 @@ public class ReJoin {
 
         if (player.getGameMode() != GameMode.SURVIVAL) {
             Bukkit.getScheduler().runTaskLater(BedWars.plugin, () -> {
-                player.setGameMode(GameMode.SURVIVAL);
+                player.setGameMode(Arena.getConfiguredGameMode(ConfigPath.GENERAL_CONFIGURATION_PLAYER_GAMEMODE_IN_GAME, GameMode.SURVIVAL));
                 player.setAllowFlight(true);
                 player.setFlying(true);
             }, 20L);

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/tasks/GamePlayingTask.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/tasks/GamePlayingTask.java
@@ -31,6 +31,7 @@ import com.andrei1058.bedwars.api.language.Language;
 import com.andrei1058.bedwars.api.language.Messages;
 import com.andrei1058.bedwars.api.tasks.PlayingTask;
 import com.andrei1058.bedwars.arena.Arena;
+import com.andrei1058.bedwars.listeners.InvisibilityPotionListener;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -234,16 +235,31 @@ public class GamePlayingTask implements Runnable, PlayingTask {
         /* INVISIBILITY FOR ARMOR */
         if (!getArena().getShowTime().isEmpty()) {
             for (Map.Entry<Player, Integer> e : getArena().getShowTime().entrySet()) {
-                if (e.getValue() <= 0) {
+                // Scadenza: timer plugin a 0 OPPURE effetto già rimosso da vanilla in anticipo.
+                boolean effectGone = !e.getKey().hasPotionEffect(PotionEffectType.INVISIBILITY);
+                if (e.getValue() <= 0 || effectGone) {
+                    e.getKey().removePotionEffect(PotionEffectType.INVISIBILITY);
                     for (Player p : e.getKey().getWorld().getPlayers()) {
                         nms.showArmor(e.getKey(), p);
-                        //nms.showPlayer(e.getKey(), p);
                     }
-                    e.getKey().removePotionEffect(PotionEffectType.INVISIBILITY);
                     getArena().getShowTime().remove(e.getKey());
-                    Bukkit.getPluginManager().callEvent(new PlayerInvisibilityPotionEvent(PlayerInvisibilityPotionEvent.Type.REMOVED, getArena().getTeam(e.getKey()), e.getKey(), getArena()));
+                    Bukkit.getPluginManager().callEvent(new PlayerInvisibilityPotionEvent(
+                            PlayerInvisibilityPotionEvent.Type.REMOVED,
+                            getArena().getTeam(e.getKey()), e.getKey(), getArena()));
                 } else {
                     getArena().getShowTime().replace(e.getKey(), e.getValue() - 1);
+
+                    // Re-invio hideArmor ogni 2s come fallback: il server vanilla puo' re-inviare
+                    // l'armatura reale (es. dopo bere pozione, cambio item in mano, ecc.).
+                    // Il task gira ogni 20 tick (1s), il contatore scala di 1/s → % 2 = ogni 2s.
+                    if (e.getValue() % 2 == 0) {
+                        for (Player p : e.getKey().getWorld().getPlayers()) {
+                            if (p.equals(e.getKey())) continue;
+                            if (InvisibilityPotionListener.shouldHideArmorForViewer(getArena(), e.getKey(), p)) {
+                                nms.hideArmor(e.getKey(), p);
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/tasks/GameRestartingTask.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/tasks/GameRestartingTask.java
@@ -32,6 +32,7 @@ import com.andrei1058.bedwars.arena.Misc;
 import com.andrei1058.bedwars.configuration.Sounds;
 import com.andrei1058.bedwars.support.paper.TeleportManager;
 import org.bukkit.Bukkit;
+import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
@@ -55,6 +56,17 @@ public class GameRestartingTask implements Runnable, RestartingTask {
         task = Bukkit.getScheduler().runTaskTimer(BedWars.plugin, this, 0, 20L);
         Sounds.playSound("game-end", arena.getPlayers());
         Sounds.playSound("game-end", arena.getSpectators());
+
+        if (arena.getConfig().getGameOverridableBoolean(ConfigPath.GENERAL_GAME_END_FORCE_SPECTATOR_BEFORE_LOBBY)) {
+            GameMode postGameSpectatorMode = parseGameMode(
+                    arena.getConfig().getGameOverridableString(ConfigPath.GENERAL_GAME_END_FORCE_SPECTATOR_GAMEMODE),
+                    GameMode.SPECTATOR
+            );
+            for (Player player : new ArrayList<>(arena.getPlayers())) {
+                arena.addSpectator(player, true, null);
+                player.setGameMode(postGameSpectatorMode);
+            }
+        }
 
         // teleport to alive players
         if (arena.getConfig().getGameOverridableBoolean(ConfigPath.GENERAL_GAME_END_TELEPORT_ELIMINATED)) {
@@ -148,6 +160,17 @@ public class GameRestartingTask implements Runnable, RestartingTask {
 
     public void cancel() {
         task.cancel();
+    }
+
+    private static GameMode parseGameMode(String value, GameMode fallback) {
+        if (value == null || value.trim().isEmpty()) {
+            return fallback;
+        }
+        try {
+            return GameMode.valueOf(value.trim().toUpperCase());
+        } catch (IllegalArgumentException ignored) {
+            return fallback;
+        }
     }
 
 }

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/tasks/GameStartingTask.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/tasks/GameStartingTask.java
@@ -147,6 +147,17 @@ public class GameStartingTask implements Runnable, StartingTask {
             return;
         }
 
+        // Aggiornamento Barra XP ad ogni secondo
+        int total = BedWars.config.getInt(ConfigPath.GENERAL_CONFIGURATION_START_COUNTDOWN_REGULAR);
+        float progress = (float) getCountdown() / Math.max(1, total);
+        if (progress < 0f) progress = 0f;
+        if (progress > 1f) progress = 1f;
+        float finalProgress = progress;
+        for (Player player : getArena().getPlayers()) {
+            player.setLevel(getCountdown());
+            player.setExp(finalProgress);
+        }
+
         //Send countdown
         if (getCountdown() % 10 == 0 || getCountdown() <= 5) {
             if (getCountdown() < 5) {
@@ -168,6 +179,20 @@ public class GameStartingTask implements Runnable, StartingTask {
     private void spawnPlayers() {
         for (ITeam bwt : getArena().getTeams()) {
             for (Player p : new ArrayList<>(bwt.getMembers())) {
+                // MOD [DEBUG] FASE 1 - Ripristina il livello BedWars reale sulla barra XP
+                // invece di azzerare, mostriamo il livello e il progresso corretti del player
+                com.andrei1058.bedwars.levels.internal.PlayerLevel pl =
+                        com.andrei1058.bedwars.levels.internal.PlayerLevel.getLevelByPlayer(p.getUniqueId());
+                if (pl != null) {
+                    p.setLevel(pl.getLevel());
+                    float xpProgress = (float) pl.getCurrentXp() / Math.max(1, pl.getNextLevelCost());
+                    if (xpProgress < 0f) xpProgress = 0f;
+                    if (xpProgress > 1f) xpProgress = 1f;
+                    p.setExp(xpProgress);
+                } else {
+                    p.setLevel(0);
+                    p.setExp(0f);
+                }
                 BedWarsTeam.reSpawnInvulnerability.put(p.getUniqueId(), System.currentTimeMillis() + 2000L);
                 bwt.firstSpawn(p);
                 Sounds.playSound(ConfigPath.SOUND_GAME_START, p);

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/team/BedWarsTeam.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/team/BedWarsTeam.java
@@ -146,7 +146,7 @@ public class BedWarsTeam implements ITeam {
     public void firstSpawn(Player p) {
         if (p == null) return;
         TeleportManager.teleportC(p, spawn, PlayerTeleportEvent.TeleportCause.PLUGIN);
-        p.setGameMode(GameMode.SURVIVAL);
+        p.setGameMode(Arena.getConfiguredGameMode(ConfigPath.GENERAL_CONFIGURATION_PLAYER_GAMEMODE_IN_GAME, GameMode.SURVIVAL));
         p.setCanPickupItems(true);
         nms.setCollide(p, getArena(), true);
         sendDefaultInventory(p, true);

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/team/BedWarsTeam.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/arena/team/BedWarsTeam.java
@@ -36,6 +36,7 @@ import com.andrei1058.bedwars.api.upgrades.EnemyBaseEnterTrap;
 import com.andrei1058.bedwars.arena.Arena;
 import com.andrei1058.bedwars.arena.OreGenerator;
 import com.andrei1058.bedwars.configuration.Sounds;
+import com.andrei1058.bedwars.listeners.InvisibilityPotionListener;
 import com.andrei1058.bedwars.shop.ShopCache;
 import com.andrei1058.bedwars.support.paper.TeleportManager;
 import org.bukkit.*;
@@ -371,6 +372,11 @@ public class BedWarsTeam implements ITeam {
             sc.managePermanentsAndDowngradables(getArena());
         }
         p.setHealth(20);
+
+        // Ripristina la barra XP BedWars: il respawn vanilla può resettarla a 0.
+        com.andrei1058.bedwars.levels.internal.PlayerLevel bwLevel =
+                com.andrei1058.bedwars.levels.internal.PlayerLevel.getLevelByPlayer(p.getUniqueId());
+        if (bwLevel != null) bwLevel.updateXpBar(p);
         if (!getBaseEffects().isEmpty()) {
             for (PotionEffect ef : getBaseEffects()) {
                 p.addPotionEffect(ef, true);
@@ -429,7 +435,9 @@ public class BedWarsTeam implements ITeam {
 
                 // #274
                 for (Player on : getArena().getShowTime().keySet()) {
-                    BedWars.nms.hideArmor(on, p);
+                    if (InvisibilityPotionListener.shouldHideArmorForViewer(getArena(), on, p)) {
+                        BedWars.nms.hideArmor(on, p);
+                    }
                 }
             }
             //
@@ -639,11 +647,11 @@ public class BedWarsTeam implements ITeam {
         Bukkit.getScheduler().runTaskLater(BedWars.plugin, () -> {
             for (Player m : getMembers()) {
                 if (m.hasPotionEffect(PotionEffectType.INVISIBILITY)) {
-                    for (Player p : getArena().getPlayers()) {
-                        BedWars.nms.hideArmor(m, p);
-                    }
-                    for (Player p : getArena().getSpectators()) {
-                        BedWars.nms.hideArmor(m, p);
+                    for (Player p : m.getWorld().getPlayers()) {
+                        if (p.equals(m)) continue;
+                        if (InvisibilityPotionListener.shouldHideArmorForViewer(getArena(), m, p)) {
+                            BedWars.nms.hideArmor(m, p);
+                        }
                     }
                 }
             }

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/configuration/LevelsConfig.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/configuration/LevelsConfig.java
@@ -70,6 +70,8 @@ public class LevelsConfig extends ConfigManager {
         levels.getYml().addDefault("progress-bar.locked-color", "&7");
         levels.getYml().addDefault("progress-bar.format", "&8 [{progress}&8]");
 
+        levels.getYml().addDefault("xp-bar.show-level", true);
+
         levels.save();
     }
 
@@ -115,5 +117,14 @@ public class LevelsConfig extends ConfigManager {
             }
         }
         return levels.getYml().getInt("levels.others.rankup-cost");
+    }
+
+    /**
+     * Get whether to show BedWars level/progress on XP bar.
+     * true = display BedWars level and progress on vanilla XP bar (custom behavior)
+     * false = keep vanilla XP bar (standard Minecraft behavior)
+     */
+    public static boolean isXpBarShowLevelEnabled() {
+        return levels.getYml().getBoolean("xp-bar.show-level", true);
     }
 }

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/configuration/MainConfig.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/configuration/MainConfig.java
@@ -124,6 +124,11 @@ public class MainConfig extends ConfigManager {
         // tnt prime settings
         yml.addDefault(ConfigPath.GENERAL_TNT_AUTO_IGNITE, true);
         yml.addDefault(ConfigPath.GENERAL_TNT_FUSE_TICKS, 45);
+        yml.addDefault(ConfigPath.GENERAL_TNT_COUNTDOWN_ENABLED, true);
+        yml.addDefault(ConfigPath.GENERAL_TNT_COUNTDOWN_NAME_VISIBLE, true);
+        yml.addDefault(ConfigPath.GENERAL_TNT_COUNTDOWN_FORMAT, "&c{seconds}s");
+        yml.addDefault(ConfigPath.GENERAL_TNT_COUNTDOWN_DECIMALS, 1);
+        yml.addDefault(ConfigPath.GENERAL_TNT_COUNTDOWN_UPDATE_INTERVAL, 1);
 
         // fireball category
         yml.addDefault(ConfigPath.GENERAL_FIREBALL_EXPLOSION_SIZE, 3);
@@ -202,6 +207,14 @@ public class MainConfig extends ConfigManager {
         yml.addDefault(ConfigPath.CENERAL_CONFIGURATION_ALLOWED_COMMANDS, Arrays.asList("shout", "bw", "leave"));
         yml.addDefault(ConfigPath.GENERAL_CONFIGURATION_EXPERIMENTAL_TEAM_ASSIGNER, true);
         yml.addDefault(ConfigPath.GENERAL_CONFIGURATION_ENABLE_GEN_SPLIT, true);
+        yml.addDefault(ConfigPath.GENERAL_CONFIGURATION_GEN_SPLIT_RADIUS, 1.5);
+        // MOD G25.2 - Quick Deposit (default: false)
+        yml.addDefault(ConfigPath.GENERAL_CONFIGURATION_ENABLE_QUICK_DEPOSIT, false);
+        // MOD G25.2 - Invisibilita': soppressione suoni/particelle (default: entrambi true)
+        yml.addDefault(ConfigPath.INVISIBILITY_SUPPRESS_FOOTSTEPS, true);
+        yml.addDefault(ConfigPath.INVISIBILITY_SUPPRESS_PARTICLES, true);
+        // MOD G25.2 - Invisibilita': i compagni di team vedono l'armatura? (default: false)
+        yml.addDefault(ConfigPath.INVISIBILITY_TEAM_CAN_SEE_ARMOR, false);
 
         yml.addDefault(ConfigPath.LOBBY_VOID_TELEPORT_ENABLED, true);
         yml.addDefault(ConfigPath.LOBBY_VOID_TELEPORT_HEIGHT, 0);

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/configuration/MainConfig.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/configuration/MainConfig.java
@@ -218,8 +218,19 @@ public class MainConfig extends ConfigManager {
 
         yml.addDefault(ConfigPath.LOBBY_VOID_TELEPORT_ENABLED, true);
         yml.addDefault(ConfigPath.LOBBY_VOID_TELEPORT_HEIGHT, 0);
+        yml.addDefault(ConfigPath.GENERAL_CONFIGURATION_PLAYER_GAMEMODE_IN_GAME, "SURVIVAL");
+        yml.addDefault(ConfigPath.GENERAL_CONFIGURATION_PLAYER_GAMEMODE_LOBBY, "SURVIVAL");
+        yml.addDefault(ConfigPath.GENERAL_CONFIGURATION_SPECTATOR_GAMEMODE, "ADVENTURE");
+        yml.addDefault(ConfigPath.GENERAL_CONFIGURATION_SPECTATOR_TRANSPARENCY, true);
+        yml.addDefault(ConfigPath.GENERAL_CONFIGURATION_SPECTATOR_TAB_SPECTATORS_SEE_PLAYERS, true);
+        yml.addDefault(ConfigPath.GENERAL_CONFIGURATION_SPECTATOR_TAB_SPECTATORS_SEE_SPECTATORS, true);
+        yml.addDefault(ConfigPath.GENERAL_CONFIGURATION_SPECTATOR_TAB_PLAYERS_SEE_SPECTATORS, false);
         yml.addDefault(ConfigPath.GENERAL_GAME_END_SHOW_ELIMINATED, true);
         yml.addDefault(ConfigPath.GENERAL_GAME_END_TELEPORT_ELIMINATED, true);
+        yml.addDefault(ConfigPath.GENERAL_GAME_END_FORCE_SPECTATOR_BEFORE_LOBBY, true);
+        yml.addDefault(ConfigPath.GENERAL_GAME_END_FORCE_SPECTATOR_GAMEMODE, "SPECTATOR");
+        yml.addDefault(ConfigPath.GENERAL_GAME_END_CLEAR_CHAT_BEFORE_ANNOUNCEMENT, true);
+        yml.addDefault(ConfigPath.GENERAL_GAME_END_CLEAR_CHAT_LINES, 120);
         yml.addDefault(ConfigPath.GENERAL_GAME_END_CHAT_TOP_STATISTIC, DefaultStatistics.KILLS.toString());
         yml.addDefault(ConfigPath.GENERAL_GAME_END_CHAT_TOP_HIDE_MISSING, true);
 

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/levels/internal/InternalLevel.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/levels/internal/InternalLevel.java
@@ -26,53 +26,73 @@ import org.bukkit.entity.Player;
 
 public class InternalLevel implements Level {
 
+    private PlayerLevel getLevelOrNull(Player p) {
+        return PlayerLevel.getOrNull(p.getUniqueId());
+    }
+
     @Override
     public String getLevel(Player p) {
-        return PlayerLevel.getLevelByPlayer(p.getUniqueId()).getLevelName();
+        PlayerLevel level = getLevelOrNull(p);
+        return null == level ? "1" : level.getLevelName();
     }
 
     @Override
     public int getPlayerLevel(Player p) {
-        return PlayerLevel.getLevelByPlayer(p.getUniqueId()).getPlayerLevel();
+        PlayerLevel level = getLevelOrNull(p);
+        return null == level ? 1 : level.getPlayerLevel();
     }
 
     @Override
     public String getRequiredXpFormatted(Player p) {
-        return PlayerLevel.getLevelByPlayer(p.getUniqueId()).getFormattedRequiredXp();
+        PlayerLevel level = getLevelOrNull(p);
+        return null == level ? "0" : level.getFormattedRequiredXp();
     }
 
     @Override
     public String getProgressBar(Player p) {
-        return PlayerLevel.getLevelByPlayer(p.getUniqueId()).getProgress();
+        PlayerLevel level = getLevelOrNull(p);
+        return null == level ? "" : level.getProgress();
     }
 
     @Override
     public int getCurrentXp(Player p) {
-        return PlayerLevel.getLevelByPlayer(p.getUniqueId()).getCurrentXp();
+        PlayerLevel level = getLevelOrNull(p);
+        return null == level ? 0 : level.getCurrentXp();
     }
 
     @Override
     public String getCurrentXpFormatted(Player p) {
-        return PlayerLevel.getLevelByPlayer(p.getUniqueId()).getFormattedCurrentXp();
+        PlayerLevel level = getLevelOrNull(p);
+        return null == level ? "0" : level.getFormattedCurrentXp();
     }
 
     @Override
     public int getRequiredXp(Player p) {
-        return PlayerLevel.getLevelByPlayer(p.getUniqueId()).getNextLevelCost();
+        PlayerLevel level = getLevelOrNull(p);
+        return null == level ? 0 : level.getNextLevelCost();
     }
 
     @Override
     public void addXp(Player player, int xp, PlayerXpGainEvent.XpSource source) {
-        PlayerLevel.getLevelByPlayer(player.getUniqueId()).addXp(xp, source);
+        PlayerLevel level = getLevelOrNull(player);
+        if (null != level) {
+            level.addXp(xp, source);
+        }
     }
 
     @Override
     public void setXp(Player player, int currentXp) {
-        PlayerLevel.getLevelByPlayer(player.getUniqueId()).setXp(currentXp);
+        PlayerLevel level = getLevelOrNull(player);
+        if (null != level) {
+            level.setXp(currentXp);
+        }
     }
 
     @Override
     public void setLevel(Player player, int level) {
-        PlayerLevel.getLevelByPlayer(player.getUniqueId()).setLevel(level);
+        PlayerLevel playerLevel = getLevelOrNull(player);
+        if (null != playerLevel) {
+            playerLevel.setLevel(level);
+        }
     }
 }

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/levels/internal/LevelListeners.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/levels/internal/LevelListeners.java
@@ -46,6 +46,19 @@ public class LevelListeners implements Listener {
 
     public LevelListeners() {
         instance = this;
+        // Refresh periodico della barra XP vanilla ogni 3 secondi per tutti i player online.
+        // applyXpBar salta automaticamente durante la fase 'starting' (usata per il countdown).
+        // Usiamo getOrNull per evitare di creare un PlayerLevel vuoto (livello 1) se non ancora
+        // caricato dal DB.
+        // BUGFIX: Aggiorna solo dopo che i dati sono stati caricati dal DB (lazyLoad completato)
+        Bukkit.getScheduler().runTaskTimer(BedWars.plugin, () -> {
+            if (!LevelsConfig.isXpBarShowLevelEnabled()) return;
+            for (Player p : Bukkit.getOnlinePlayers()) {
+                PlayerLevel pl = PlayerLevel.getOrNull(p.getUniqueId());
+                // Aggiorna solo se i dati sono stati caricati dal DB
+                if (pl != null && pl.isDataLoaded()) pl.updateXpBar(p);
+            }
+        }, 60L, 60L);
     }
 
     //create new level data on player join
@@ -55,11 +68,14 @@ public class LevelListeners implements Listener {
         // create empty level first
         new PlayerLevel(u, 1, 0);
         Bukkit.getScheduler().runTaskAsynchronously(BedWars.plugin, () -> {
-            //if (PlayerLevel.getLevelByPlayer(e.getPlayer().getUniqueId()) != null) return;
             Object[] levelData = BedWars.getRemoteDatabase().getLevelData(u);
-            PlayerLevel.getLevelByPlayer(u).lazyLoad((Integer) levelData[0], (Integer) levelData[1]);
-            //new PlayerLevel(e.getPlayer().getUniqueId(), (Integer)levelData[0], (Integer)levelData[1]);
-            //Bukkit.broadcastMessage("LAZY LOAD");
+            PlayerLevel pl = PlayerLevel.getLevelByPlayer(u);
+            pl.lazyLoad((Integer) levelData[0], (Integer) levelData[1]);
+            // MOD [DEBUG] FASE 1 - Aggiorna barra XP vanilla sul main thread dopo il caricamento DB
+            Bukkit.getScheduler().runTask(BedWars.plugin, () -> {
+                Player p = Bukkit.getPlayer(u);
+                if (p != null) pl.updateXpBar(p);
+            });
         });
     }
 
@@ -122,6 +138,12 @@ public class LevelListeners implements Listener {
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onArenaLeave(PlayerLeaveArenaEvent e) {
         final UUID u = e.getPlayer().getUniqueId();
+        // MOD [DEBUG] FASE 2 - Aggiorna barra XP vanilla al rientro dalla partita
+        Bukkit.getScheduler().runTaskLater(BedWars.plugin, () -> {
+            Player p = Bukkit.getPlayer(u);
+            PlayerLevel pl = PlayerLevel.getLevelByPlayer(u);
+            if (p != null && pl != null) pl.updateXpBar(p);
+        }, 5L);
         Bukkit.getScheduler().runTaskAsynchronously(BedWars.plugin, () -> {
             PlayerLevel pl = PlayerLevel.getLevelByPlayer(u);
             if (pl != null) pl.updateDatabase();

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/levels/internal/LevelListeners.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/levels/internal/LevelListeners.java
@@ -29,7 +29,9 @@ import com.andrei1058.bedwars.api.events.player.PlayerLeaveArenaEvent;
 import com.andrei1058.bedwars.api.events.player.PlayerXpGainEvent;
 import com.andrei1058.bedwars.api.language.Language;
 import com.andrei1058.bedwars.api.language.Messages;
+import com.andrei1058.bedwars.arena.Arena;
 import com.andrei1058.bedwars.configuration.LevelsConfig;
+import com.andrei1058.bedwars.sidebar.SidebarService;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -70,11 +72,24 @@ public class LevelListeners implements Listener {
         Bukkit.getScheduler().runTaskAsynchronously(BedWars.plugin, () -> {
             Object[] levelData = BedWars.getRemoteDatabase().getLevelData(u);
             PlayerLevel pl = PlayerLevel.getLevelByPlayer(u);
+            if (pl == null) {
+                return;
+            }
             pl.lazyLoad((Integer) levelData[0], (Integer) levelData[1]);
-            // MOD [DEBUG] FASE 1 - Aggiorna barra XP vanilla sul main thread dopo il caricamento DB
+
+            // Ensure sidebar placeholders are rebuilt once DB level data becomes available.
             Bukkit.getScheduler().runTask(BedWars.plugin, () -> {
                 Player p = Bukkit.getPlayer(u);
-                if (p != null) pl.updateXpBar(p);
+                if (p == null || !p.isOnline()) {
+                    return;
+                }
+
+                pl.updateXpBar(p);
+
+                SidebarService sidebarService = SidebarService.getInstance();
+                if (sidebarService != null) {
+                    sidebarService.giveSidebar(p, Arena.getArenaByPlayer(p), false);
+                }
             });
         });
     }

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/levels/internal/PlayerLevel.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/levels/internal/PlayerLevel.java
@@ -45,6 +45,8 @@ public class PlayerLevel {
 
     // keep trace if current level is different than the one in database
     private boolean modified = false;
+    // keep trace if data has been loaded from database
+    private boolean dataLoaded = false;
 
     private static ConcurrentHashMap<UUID, PlayerLevel> levelByPlayer = new ConcurrentHashMap<>();
 
@@ -90,6 +92,14 @@ public class PlayerLevel {
         updateProgressBar();
 
         modified = false;
+        dataLoaded = true;
+    }
+
+    /**
+     * Check if data has been loaded from database.
+     */
+    public boolean isDataLoaded() {
+        return dataLoaded;
     }
 
     /**
@@ -108,7 +118,45 @@ public class PlayerLevel {
                         + LevelsConfig.levels.getString("progress-bar.locked-color") + String.valueOf(new char[locked]).replace("\0", LevelsConfig.levels.getString("progress-bar.symbol"))));
         requiredXp = formatNumber(nextLevelCost);
         formattedCurrentXp = formatNumber(currentXp);
+        updateXpBar(Bukkit.getPlayer(uuid));
     }
+
+    /**
+     * Aggiorna la barra dell'XP vanilla con il livello e il progresso BedWars.
+     * Thread-safe: se chiamato da un thread asincrono (es. lazyLoad dal DB),
+     * schedula le chiamate Bukkit sul main thread.
+     * Non aggiornare durante la fase 'starting' dove la barra XP e' usata per il timer.
+     */
+    public void updateXpBar(org.bukkit.entity.Player p) {
+        if (p == null || !p.isOnline()) return;
+
+        // Calcola i valori prima di toccare Bukkit API (sicuro anche su thread async)
+        final int lvl = this.level;
+        float rawProgress = (float) this.currentXp / Math.max(1, this.nextLevelCost);
+        if (rawProgress < 0f) rawProgress = 0f;
+        if (rawProgress > 1f) rawProgress = 1f;
+        final float progress = rawProgress;
+
+        if (!Bukkit.isPrimaryThread()) {
+            // Chiamato da thread async: schedula sul main thread
+            Bukkit.getScheduler().runTask(BedWars.plugin, () -> applyXpBar(p, lvl, progress));
+        } else {
+            applyXpBar(p, lvl, progress);
+        }
+    }
+
+    /**
+     * Applica i valori della barra XP al player. DEVE essere chiamato sul main thread.
+     */
+    private void applyXpBar(org.bukkit.entity.Player p, int lvl, float progress) {
+        if (!p.isOnline()) return;
+        com.andrei1058.bedwars.api.arena.IArena arena = com.andrei1058.bedwars.arena.Arena.getArenaByPlayer(p);
+        // Salta SOLO durante il conto alla rovescia pre-partita (barra usata per il timer)
+        if (arena != null && arena.getStatus() == com.andrei1058.bedwars.api.arena.GameState.starting) return;
+        p.setLevel(lvl);
+        p.setExp(progress);
+    }
+
 
     /**
      * Get player current level.
@@ -125,10 +173,22 @@ public class PlayerLevel {
     }
 
     /**
-     * Get PlayerLevel by player.
+     * Get PlayerLevel by player. Returns null if not found (should always exist after join).
+     * Use getOrNull() instead which is clearer about the intent.
+     * @deprecated Use getOrNull() instead
      */
+    @Deprecated
     public static PlayerLevel getLevelByPlayer(UUID player) {
-        return levelByPlayer.getOrDefault(player, new PlayerLevel(player, 1, 0));
+        // BUGFIX: Non crea più un livello 1 falso se non trovato - ritorna null come getOrNull()
+        return levelByPlayer.get(player);
+    }
+
+    /**
+     * Get PlayerLevel by player without creating a default entry.
+     * Returns null if the player data hasn't been loaded yet.
+     */
+    public static PlayerLevel getOrNull(UUID player) {
+        return levelByPlayer.get(player);
     }
 
     /**

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/BreakPlace.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/BreakPlace.java
@@ -41,6 +41,7 @@ import com.andrei1058.bedwars.popuptower.TowerEast;
 import com.andrei1058.bedwars.popuptower.TowerNorth;
 import com.andrei1058.bedwars.popuptower.TowerSouth;
 import com.andrei1058.bedwars.popuptower.TowerWest;
+import org.bukkit.ChatColor;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -61,6 +62,7 @@ import org.bukkit.event.hanging.HangingBreakByEntityEvent;
 import org.bukkit.event.player.PlayerBucketEmptyEvent;
 import org.bukkit.event.player.PlayerBucketFillEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.scheduler.BukkitRunnable;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
@@ -173,6 +175,7 @@ public class BreakPlace implements Listener {
                     TNTPrimed tnt = Objects.requireNonNull(e.getBlock().getLocation().getWorld()).spawn(e.getBlock().getLocation().add(0.5, 0, 0.5), TNTPrimed.class);
                     tnt.setFuseTicks(config.getInt(ConfigPath.GENERAL_TNT_FUSE_TICKS));
                     nms.setSource(tnt, p);
+                    showTntCountdown(tnt);
                     return;
                 }
             } else if (BedWars.shop.getBoolean(ConfigPath.SHOP_SPECIAL_TOWER_ENABLE)) {
@@ -208,6 +211,37 @@ public class BreakPlace implements Listener {
                 }
             }
         }
+    }
+
+    private void showTntCountdown(@NotNull TNTPrimed tnt) {
+        if (!config.getBoolean(ConfigPath.GENERAL_TNT_COUNTDOWN_ENABLED)) {
+            return;
+        }
+
+        final String displayFormat = Objects.requireNonNullElse(
+                config.getString(ConfigPath.GENERAL_TNT_COUNTDOWN_FORMAT),
+                "&c{seconds}s"
+        );
+        final int decimals = Math.max(0, config.getInt(ConfigPath.GENERAL_TNT_COUNTDOWN_DECIMALS));
+        final long updateInterval = Math.max(1, config.getInt(ConfigPath.GENERAL_TNT_COUNTDOWN_UPDATE_INTERVAL));
+        tnt.setCustomNameVisible(config.getBoolean(ConfigPath.GENERAL_TNT_COUNTDOWN_NAME_VISIBLE));
+
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                if (!tnt.isValid() || tnt.isDead()) {
+                    cancel();
+                    return;
+                }
+                int fuseTicks = Math.max(0, tnt.getFuseTicks());
+                double secondsLeft = fuseTicks / 20.0D;
+                String seconds = String.format(Locale.US, "%." + decimals + "f", secondsLeft);
+                String countdownName = displayFormat
+                        .replace("{seconds}", seconds)
+                        .replace("{ticks}", String.valueOf(fuseTicks));
+                tnt.setCustomName(ChatColor.translateAlternateColorCodes('&', countdownName));
+            }
+        }.runTaskTimer(BedWars.plugin, 0L, updateInterval);
     }
 
     @EventHandler(ignoreCancelled = true)

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/DamageDeathMove.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/DamageDeathMove.java
@@ -38,6 +38,7 @@ import com.andrei1058.bedwars.arena.Arena;
 import com.andrei1058.bedwars.arena.LastHit;
 import com.andrei1058.bedwars.arena.SetupSession;
 import com.andrei1058.bedwars.arena.team.BedWarsTeam;
+import com.andrei1058.bedwars.listeners.InvisibilityPotionListener;
 import com.andrei1058.bedwars.configuration.Sounds;
 import com.andrei1058.bedwars.listeners.dropshandler.PlayerDrops;
 import com.andrei1058.bedwars.support.paper.TeleportManager;
@@ -333,6 +334,10 @@ public class DamageDeathMove implements Listener {
             e.setDeathMessage(null);
         }
         if (a != null) {
+            // Impedisce a vanilla di azzerare il livello XP (usato per la barra BedWars).
+            e.setKeepLevel(true);
+            e.setDroppedExp(0);
+
             if (a.isSpectator(victim)) {
                 victim.spigot().respawn();
                 return;
@@ -598,18 +603,18 @@ public class DamageDeathMove implements Listener {
                     // generic hide packets
                     for (Map.Entry<Player, Integer> entry : a.getShowTime().entrySet()) {
                         if (entry.getValue() > 1) {
-                            BedWars.nms.hideArmor(entry.getKey(), e.getPlayer());
+                            if (InvisibilityPotionListener.shouldHideArmorForViewer(a, entry.getKey(), e.getPlayer())) {
+                                BedWars.nms.hideArmor(entry.getKey(), e.getPlayer());
+                            }
                         }
                     }
                     // if the moving player has invisible armor
                     if (a.getShowTime().containsKey(e.getPlayer())) {
-                        for (Player p : a.getPlayers()) {
-                            nms.hideArmor(e.getPlayer(), p);
-                        }
-                    }
-                    if (a.getShowTime().containsKey(e.getPlayer())) {
-                        for (Player p : a.getSpectators()) {
-                            nms.hideArmor(e.getPlayer(), p);
+                        for (Player p : e.getPlayer().getWorld().getPlayers()) {
+                            if (p.equals(e.getPlayer())) continue;
+                            if (InvisibilityPotionListener.shouldHideArmorForViewer(a, e.getPlayer(), p)) {
+                                nms.hideArmor(e.getPlayer(), p);
+                            }
                         }
                     }
                 }

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/Inventory.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/Inventory.java
@@ -23,6 +23,7 @@ package com.andrei1058.bedwars.listeners;
 import com.andrei1058.bedwars.BedWars;
 import com.andrei1058.bedwars.api.arena.GameState;
 import com.andrei1058.bedwars.api.arena.IArena;
+import com.andrei1058.bedwars.listeners.InvisibilityPotionListener;
 import com.andrei1058.bedwars.api.events.gameplay.GameStateChangeEvent;
 import com.andrei1058.bedwars.api.language.Language;
 import com.andrei1058.bedwars.api.language.Messages;
@@ -129,11 +130,14 @@ public class Inventory implements Listener {
 
         //issue #225
         if (e.getSlotType() == InventoryType.SlotType.ARMOR) {
-            if (Arena.getArenaByPlayer((Player) e.getWhoClicked()) != null) {
+            IArena a = Arena.getArenaByPlayer((Player) e.getWhoClicked());
+            if (a != null) {
                 if (e.getWhoClicked().hasPotionEffect(PotionEffectType.INVISIBILITY)) {
                     e.getWhoClicked().closeInventory();
                     for (Player pl : e.getWhoClicked().getWorld().getPlayers()) {
-                        BedWars.nms.hideArmor((Player) e.getWhoClicked(), pl);
+                        if (InvisibilityPotionListener.shouldHideArmorForViewer(a, (Player) e.getWhoClicked(), pl)) {
+                            BedWars.nms.hideArmor((Player) e.getWhoClicked(), pl);
+                        }
                     }
                 }
             }

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/InvisibilityPacketListener.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/InvisibilityPacketListener.java
@@ -1,0 +1,171 @@
+/*
+ * BedWars1058 - A bed wars mini-game.
+ * Copyright (C) 2021 Andrei Dascălu
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact e-mail: andrew.dascalu@gmail.com
+ */
+
+package com.andrei1058.bedwars.listeners;
+
+import com.andrei1058.bedwars.BedWars;
+import com.andrei1058.bedwars.api.arena.GameState;
+import com.andrei1058.bedwars.api.arena.IArena;
+import com.andrei1058.bedwars.api.configuration.ConfigPath;
+import com.andrei1058.bedwars.arena.Arena;
+import com.comphenix.protocol.PacketType;
+import com.comphenix.protocol.ProtocolLibrary;
+import com.comphenix.protocol.ProtocolManager;
+import com.comphenix.protocol.events.ListenerPriority;
+import com.comphenix.protocol.events.PacketAdapter;
+import com.comphenix.protocol.events.PacketEvent;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.potion.PotionEffectType;
+
+/**
+ * Autore: Giustino C. Miglionico con l'aiuto della tecnologia peruviana
+ *
+ * Logica di Implementazione:
+ * FASE 1 - Intercettazione NAMED_SOUND_EFFECT (opzionale, da config)
+ *   Obiettivo: Sopprimere i suoni di footstep per i giocatori invisibili nell'arena.
+ *   Scelta tecnica: Intercetto il pacchetto NAMED_SOUND_EFFECT, controllo se la sorgente
+ *   sonora coincide con un giocatore invisibile nell'arena. Se suppress-footstep-sounds=true,
+ *   cancello il pacchetto per i ricevitori che sono nemici.
+ *
+ * FASE 2 - Intercettazione WORLD_PARTICLES (opzionale, da config)
+ *   Obiettivo: Sopprimere le particelle emesse dai giocatori invisibili.
+ *   Scelta tecnica: Intercetto WORLD_PARTICLES e cancello i pacchetti quando il
+ *   giocatore che dovrebbe vederli e' un nemico del giocatore invisibile.
+ *
+ * NOTE IMPORTANTI SUL BUG ARMATURA:
+ *   - NON intercettiamo ENTITY_EQUIPMENT perche' bloccerebbe anche i nostri stessi
+ *     pacchetti di hideArmor (che inviano slot=AIR per nascondere l'armatura).
+ *   - La gestione dell'armatura (hide/show) e' delegata a GamePlayingTask (re-hide periodico)
+ *     e a InvisibilityPotionListener (hide al bere, show allo scadere).
+ *
+ * MODIFICA 08/04/2026: Aggiunto supporto flag configurabili per suoni e particelle.
+ *                       Rimosso ENTITY_EQUIPMENT che bloccava hideArmor.
+ */
+public class InvisibilityPacketListener {
+
+    /**
+     * Registra il listener ProtocolLib per sopprimere suoni e particelle.
+     * Legge le flag dalla config al momento della registrazione.
+     *
+     * @param plugin Istanza del plugin BedWars.
+     */
+    public static void register(Plugin plugin) {
+        boolean suppressFootsteps = BedWars.config.getBoolean(ConfigPath.INVISIBILITY_SUPPRESS_FOOTSTEPS);
+        boolean suppressParticles  = BedWars.config.getBoolean(ConfigPath.INVISIBILITY_SUPPRESS_PARTICLES);
+
+        if (!suppressFootsteps && !suppressParticles) {
+            // Nessuna soppressione richiesta: non registrare nulla
+            plugin.getLogger().info("[G25.2] Invisibility packet listener disabled (flags: footsteps=false, particles=false)");
+            return;
+        }
+
+        ProtocolManager pm = ProtocolLibrary.getProtocolManager();
+
+        // [DEBUG] FASE 1 - Soppressione footstep sounds
+        if (suppressFootsteps) {
+            pm.addPacketListener(new PacketAdapter(plugin, ListenerPriority.HIGH, PacketType.Play.Server.NAMED_SOUND_EFFECT) {
+                @Override
+                public void onPacketSending(PacketEvent event) {
+                    if (event.isCancelled()) return;
+                    if (event.isPlayerTemporary()) return;
+                    Player receiver = event.getPlayer();
+                    IArena arena = Arena.getArenaByPlayer(receiver);
+                    if (arena == null || arena.getStatus() != GameState.playing) return;
+
+                    // In 1.20.4, PacketPlayOutNamedSoundEffect usa coordinate int*8 (non double)
+                    // d = X*8, e = Y*8, f = Z*8 (vedi dump pacchetto nel log)
+                    double x, y, z;
+                    try {
+                        int xi = event.getPacket().getIntegers().read(0);
+                        int yi = event.getPacket().getIntegers().read(1);
+                        int zi = event.getPacket().getIntegers().read(2);
+                        x = xi / 8.0;
+                        y = yi / 8.0;
+                        z = zi / 8.0;
+                    } catch (Exception ex) {
+                        // Fallback per versioni con coordinate come double
+                        try {
+                            x = event.getPacket().getDoubles().read(0);
+                            y = event.getPacket().getDoubles().read(1);
+                            z = event.getPacket().getDoubles().read(2);
+                        } catch (Exception ex2) {
+                            return; // Impossibile leggere le coordinate: skip
+                        }
+                    }
+                    org.bukkit.Location soundLoc = new org.bukkit.Location(receiver.getWorld(), x, y, z);
+
+                    for (Player nearby : receiver.getWorld().getPlayers()) {
+                        if (nearby.equals(receiver)) continue;
+                        if (nearby.getLocation().distanceSquared(soundLoc) > 1.0) continue;
+                        // E' abbastanza vicino alla sorgente: e' un giocatore arena?
+                        // Stesso team? Lascia passare il suono ai compagni
+                        IArena nearbyArena = Arena.getArenaByPlayer(nearby);
+                        if (nearbyArena == null || !nearbyArena.equals(arena)) continue;
+                        // Ha la pozione di invisibilita'?
+                        if (!nearby.hasPotionEffect(PotionEffectType.INVISIBILITY)) continue;
+                        // Stesso team del receiver? Non sopprimere
+                        com.andrei1058.bedwars.api.arena.team.ITeam teamReceiver = arena.getTeam(receiver);
+                        com.andrei1058.bedwars.api.arena.team.ITeam teamNearby   = arena.getTeam(nearby);
+                        if (teamReceiver != null && teamReceiver.equals(teamNearby)) continue;
+                        // Sopprimi il suono
+                        event.setCancelled(true);
+                        return;
+                    }
+                }
+            });
+            plugin.getLogger().info("[G25.2] Invisibility: footstep sound suppression ENABLED");
+        }
+
+        // [DEBUG] FASE 2 - Soppressione particelle
+        if (suppressParticles) {
+            pm.addPacketListener(new PacketAdapter(plugin, ListenerPriority.HIGH, PacketType.Play.Server.WORLD_PARTICLES) {
+                @Override
+                public void onPacketSending(PacketEvent event) {
+                    if (event.isCancelled()) return;
+                    if (event.isPlayerTemporary()) return;
+                    Player receiver = event.getPlayer();
+                    IArena arena = Arena.getArenaByPlayer(receiver);
+                    if (arena == null || arena.getStatus() != GameState.playing) return;
+
+                    double x = event.getPacket().getFloat().read(0);
+                    double y = event.getPacket().getFloat().read(1);
+                    double z = event.getPacket().getFloat().read(2);
+                    org.bukkit.Location particleLoc = new org.bukkit.Location(receiver.getWorld(), x, y, z);
+
+                    for (Player nearby : receiver.getWorld().getPlayers()) {
+                        if (nearby.equals(receiver)) continue;
+                        if (nearby.getLocation().distanceSquared(particleLoc) > 4.0) continue;
+                        // Stesso team del receiver? Non sopprimere
+                        IArena nearbyArena = Arena.getArenaByPlayer(nearby);
+                        if (nearbyArena == null || !nearbyArena.equals(arena)) continue;
+                        if (!nearby.hasPotionEffect(PotionEffectType.INVISIBILITY)) continue;
+                        com.andrei1058.bedwars.api.arena.team.ITeam teamReceiver = arena.getTeam(receiver);
+                        com.andrei1058.bedwars.api.arena.team.ITeam teamNearby   = arena.getTeam(nearby);
+                        if (teamReceiver != null && teamReceiver.equals(teamNearby)) continue;
+                        event.setCancelled(true);
+                        return;
+                    }
+                }
+            });
+            plugin.getLogger().info("[G25.2] Invisibility: particle suppression ENABLED");
+        }
+    }
+}

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/InvisibilityPotionListener.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/InvisibilityPotionListener.java
@@ -22,6 +22,7 @@ package com.andrei1058.bedwars.listeners;
 
 import com.andrei1058.bedwars.api.arena.IArena;
 import com.andrei1058.bedwars.api.arena.team.ITeam;
+import com.andrei1058.bedwars.api.configuration.ConfigPath;
 import com.andrei1058.bedwars.api.events.player.PlayerInvisibilityPotionEvent;
 import com.andrei1058.bedwars.arena.Arena;
 import com.andrei1058.bedwars.sidebar.SidebarService;
@@ -33,6 +34,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerItemConsumeEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
 import org.jetbrains.annotations.NotNull;
 
 import static com.andrei1058.bedwars.BedWars.nms;
@@ -47,6 +49,7 @@ public class InvisibilityPotionListener implements Listener {
     @EventHandler
     public void onPotion(@NotNull PlayerInvisibilityPotionEvent e) {
         if (e.getTeam() == null) return;
+        syncVisibility(e.getArena(), e.getPlayer(), e.getType() == PlayerInvisibilityPotionEvent.Type.ADDED);
         SidebarService.getInstance().handleInvisibility(
                 e.getTeam(), e.getPlayer(), e.getType() == PlayerInvisibilityPotionEvent.Type.ADDED
         );
@@ -64,41 +67,86 @@ public class InvisibilityPotionListener implements Listener {
         //
 
         if (nms.isInvisibilityPotion(e.getItem())) {
+            // Non affidarsi solo a +5 tick: su alcuni server l'effetto arriva piu' tardi.
+            applyInvisibilityWhenPresent(a, e.getPlayer(), 0);
+
+            // Secondo hideArmor a tick+20: dopo che vanilla invia ENTITY_EQUIPMENT
+            // per la rimozione della bottiglia (minusAmount a tick+5), rinasce il packet
+            // con l'armatura reale. Lo sovrascriviamo 1 secondo dopo con un nuovo hide.
             Bukkit.getScheduler().runTaskLater(plugin, () -> {
-                for (PotionEffect pe : e.getPlayer().getActivePotionEffects()) {
-                    if (pe.getType().toString().contains("INVISIBILITY")) {
-                        // if is already invisible
-                        if (a.getShowTime().containsKey(e.getPlayer())) {
-                            ITeam t = a.getTeam(e.getPlayer());
-                            // increase invisibility timer
-                            // keep trace of invisible players to send hide armor packet when required
-                            // because potions do not hide armors
-                            a.getShowTime().replace(e.getPlayer(), pe.getDuration() / 20);
-                            // call custom event
-                            Bukkit.getPluginManager().callEvent(new PlayerInvisibilityPotionEvent(PlayerInvisibilityPotionEvent.Type.ADDED, t, e.getPlayer(), t.getArena()));
-                        } else {
-                            // if not already invisible
-                            ITeam t = a.getTeam(e.getPlayer());
-                            // keep trace of invisible players to send hide armor packet when required
-                            // because potions do not hide armors
-                            a.getShowTime().put(e.getPlayer(), pe.getDuration() / 20);
-                            //
-                            for (Player p1 : e.getPlayer().getWorld().getPlayers()) {
-                                if (a.isSpectator(p1)) {
-                                    // hide player armor to spectators
-                                    nms.hideArmor(e.getPlayer(), p1);
-                                } else if (t != a.getTeam(p1)) {
-                                    // hide player armor to other teams
-                                    nms.hideArmor(e.getPlayer(), p1);
-                                }
-                            }
-                            // call custom event
-                            Bukkit.getPluginManager().callEvent(new PlayerInvisibilityPotionEvent(PlayerInvisibilityPotionEvent.Type.ADDED, t, e.getPlayer(), t.getArena()));
-                        }
-                        break;
-                    }
-                }
-            }, 5L);
+                if (!e.getPlayer().isOnline()) return;
+                if (!e.getPlayer().hasPotionEffect(PotionEffectType.INVISIBILITY)) return;
+                syncVisibility(a, e.getPlayer(), true);
+            }, 20L);
         }
     }
+
+    private void applyInvisibilityWhenPresent(IArena arena, Player player, int attempt) {
+        if (arena == null || player == null || !player.isOnline()) return;
+
+        PotionEffect invis = null;
+        for (PotionEffect pe : player.getActivePotionEffects()) {
+            if (pe.getType() == PotionEffectType.INVISIBILITY) {
+                invis = pe;
+                break;
+            }
+        }
+
+        // Riprova per ~2 secondi totali: copre lag/timing diversi nel consumo pozione.
+        if (invis == null) {
+            if (attempt >= 20) return;
+            Bukkit.getScheduler().runTaskLater(plugin, () -> applyInvisibilityWhenPresent(arena, player, attempt + 1), 2L);
+            return;
+        }
+
+        ITeam t = arena.getTeam(player);
+        int durationSeconds = Math.max(1, invis.getDuration() / 20);
+        if (arena.getShowTime().containsKey(player)) {
+            arena.getShowTime().replace(player, durationSeconds);
+        } else {
+            arena.getShowTime().put(player, durationSeconds);
+        }
+
+        syncVisibility(arena, player, true);
+        if (t != null) {
+            Bukkit.getPluginManager().callEvent(new PlayerInvisibilityPotionEvent(PlayerInvisibilityPotionEvent.Type.ADDED, t, player, t.getArena()));
+        }
+    }
+
+    public static void syncVisibility(IArena arena, Player victim, boolean hidden) {
+        if (arena == null || victim == null) return;
+        for (Player viewer : victim.getWorld().getPlayers()) {
+            if (viewer.equals(victim)) continue;
+            if (hidden) {
+                if (shouldHidePlayerForViewer(arena, victim, viewer)) {
+                    nms.spigotHidePlayer(victim, viewer);
+                    nms.hideArmor(victim, viewer);
+                } else {
+                    nms.spigotShowPlayer(victim, viewer);
+                    nms.showArmor(victim, viewer);
+                }
+            } else {
+                nms.spigotShowPlayer(victim, viewer);
+                nms.showArmor(victim, viewer);
+            }
+        }
+    }
+
+    public static boolean shouldHidePlayerForViewer(IArena arena, Player victim, Player viewer) {
+        if (arena == null || victim == null || viewer == null) return false;
+        if (viewer.equals(victim)) return false;
+        if (!plugin.getConfig().getBoolean(ConfigPath.INVISIBILITY_TEAM_CAN_SEE_ARMOR, false)) {
+            return true;
+        }
+        ITeam victimTeam = arena.getTeam(victim);
+        if (victimTeam == null) return true;
+        if (arena.isSpectator(viewer)) return true;
+        ITeam viewerTeam = arena.getTeam(viewer);
+        return viewerTeam == null || !victimTeam.equals(viewerTeam);
+    }
+
+    public static boolean shouldHideArmorForViewer(IArena arena, Player victim, Player viewer) {
+        return shouldHidePlayerForViewer(arena, victim, viewer);
+    }
+
 }

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/QuickDepositListener.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/QuickDepositListener.java
@@ -1,0 +1,194 @@
+/*
+ * BedWars1058 - A bed wars mini-game.
+ * Copyright (C) 2021 Andrei Dascălu
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contact e-mail: andrew.dascalu@gmail.com
+ */
+
+package com.andrei1058.bedwars.listeners;
+
+import com.andrei1058.bedwars.BedWars;
+import com.andrei1058.bedwars.api.arena.IArena;
+import com.andrei1058.bedwars.api.arena.team.ITeam;
+import com.andrei1058.bedwars.api.configuration.ConfigPath;
+import com.andrei1058.bedwars.arena.Arena;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.Chest;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.EnumSet;
+ import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringJoiner;
+
+/**
+ * Autore: Giustino C. Miglionico con l'aiuto della tecnologia peruviana
+ *
+ * Logica di Implementazione:
+ * FASE 1 - Rilevamento interazione
+ *   Obiettivo: Rilevare Shift + Click destro su una cassa del proprio team durante la partita.
+ *   Condizioni: feature abilitata in config, player in partita, non spettatore, cassa nella propria base.
+ *
+ * FASE 2 - Trasferimento valuta
+ *   Obiettivo: Trasferire ferro/oro/diamanti/smeraldi dall'inventario del player alla cassa.
+ *   Scelta tecnica: Iterare l'inventario del player, spostare ogni stack di currency nella cassa.
+ *   Se la cassa e' piena, il residuo resta nell'inventario del player.
+ *
+ * FASE 3 - Feedback visivo/sonoro
+ *   Obiettivo: Notificare il player con sound e messaggio del trasferimento avvenuto.
+ */
+public class QuickDepositListener implements Listener {
+
+    // Valute trasferibili — solo quelle classiche di BedWars
+    private static final Set<Material> CURRENCIES = EnumSet.of(
+            Material.IRON_INGOT,
+            Material.GOLD_INGOT,
+            Material.DIAMOND,
+            Material.EMERALD
+    );
+
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onClickChest(PlayerInteractEvent event) {
+        // Solo click sinistro attiva il deposito rapido; click destro apre normalmente.
+        if (event.getAction() != Action.LEFT_CLICK_BLOCK) return;
+
+        Block block = event.getClickedBlock();
+        if (block == null) return;
+
+        Material blockType = block.getType();
+        boolean isChest      = blockType == Material.CHEST || blockType == Material.TRAPPED_CHEST;
+        boolean isEnderChest = blockType == Material.ENDER_CHEST;
+        if (!isChest && !isEnderChest) return;
+
+        Player player = event.getPlayer();
+
+        // Feature attiva?
+        if (!BedWars.config.getBoolean(ConfigPath.GENERAL_CONFIGURATION_ENABLE_QUICK_DEPOSIT)) return;
+
+        IArena arena = Arena.getArenaByPlayer(player);
+        if (arena == null) return;
+        if (arena.isSpectator(player)) return;
+        if (arena.getRespawnSessions().containsKey(player)) return;
+
+        Inventory targetInventory;
+
+        if (isChest) {
+            // CHEST: solo se è nella base del proprio team
+            ITeam playerTeam = arena.getTeam(player);
+            if (playerTeam == null) return;
+            int isRad = arena.getConfig().getInt(ConfigPath.ARENA_ISLAND_RADIUS);
+            if (playerTeam.getSpawn().distance(block.getLocation()) > isRad) return;
+            if (!(block.getState() instanceof Chest)) return;
+            event.setCancelled(true);
+            targetInventory = ((Chest) block.getState()).getBlockInventory();
+        } else {
+            // ENDER_CHEST: sempre del player
+            event.setCancelled(true);
+            targetInventory = player.getEnderChest();
+        }
+
+        // [DEBUG] FASE 2 - Trasferimento valute con tracking per materiale
+        Map<Material, Integer> depositedPerMaterial = new LinkedHashMap<>();
+        depositedPerMaterial.put(Material.IRON_INGOT, 0);
+        depositedPerMaterial.put(Material.GOLD_INGOT, 0);
+        depositedPerMaterial.put(Material.DIAMOND, 0);
+        depositedPerMaterial.put(Material.EMERALD, 0);
+
+        boolean chestFull = false;
+        for (int i = 0; i < player.getInventory().getSize(); i++) {
+            ItemStack stack = player.getInventory().getItem(i);
+            if (stack == null || stack.getType() == Material.AIR) continue;
+            if (!CURRENCIES.contains(stack.getType())) continue;
+
+            Material mat = stack.getType();
+            ItemStack toDeposit = stack.clone();
+            java.util.HashMap<Integer, ItemStack> leftover = targetInventory.addItem(toDeposit);
+
+            if (leftover.isEmpty()) {
+                player.getInventory().setItem(i, null);
+                depositedPerMaterial.merge(mat, toDeposit.getAmount(), Integer::sum);
+            } else {
+                ItemStack remaining = leftover.values().iterator().next();
+                int deposited = toDeposit.getAmount() - remaining.getAmount();
+                if (deposited > 0) {
+                    depositedPerMaterial.merge(mat, deposited, Integer::sum);
+                    ItemStack newStack = stack.clone();
+                    newStack.setAmount(remaining.getAmount());
+                    player.getInventory().setItem(i, newStack);
+                }
+                chestFull = true;
+                break;
+            }
+        }
+
+        // [DEBUG] FASE 3 - Feedback dettagliato al player
+        int totalTransferred = depositedPerMaterial.values().stream().mapToInt(Integer::intValue).sum();
+        String destLabel = isEnderChest ? "cassa dell'End" : "cassa del team";
+        if (totalTransferred > 0) {
+            player.updateInventory();
+            // Aggiorna il block state solo per casse normali
+            if (isChest && block.getState() instanceof Chest) ((Chest) block.getState()).update();
+
+
+            StringJoiner joiner = new StringJoiner("§7; §f");
+            for (Map.Entry<Material, Integer> entry : depositedPerMaterial.entrySet()) {
+                if (entry.getValue() <= 0) continue;
+                joiner.add("§e" + entry.getValue() + "§f di §e" + getMaterialDisplayName(entry.getKey()));
+            }
+            String suffix = chestFull ? " §c(cassa piena)" : "";
+            player.sendMessage("§aDeposito rapido §7[" + destLabel + "]§r: §f" + joiner + suffix);
+            print("[DEBUG] Quick deposit [" + destLabel + "]: " + player.getName() + " -> " + depositedPerMaterial);
+        } else {
+            player.sendMessage("§cNessuna valuta da depositare nella §e" + destLabel + (chestFull ? " §c(piena)" : "") + "§c.");
+        }
+    }
+
+    /**
+     * Restituisce il nome italiano del materiale per i messaggi in-game.
+     *
+     * @param material Materiale BedWars.
+     * @return Nome leggibile in italiano.
+     */
+    private String getMaterialDisplayName(Material material) {
+        switch (material) {
+            case IRON_INGOT: return "Ferro";
+            case GOLD_INGOT: return "Oro";
+            case DIAMOND:    return "Diamante";
+            case EMERALD:    return "Smeraldo";
+            default:         return material.name();
+        }
+    }
+
+    /**
+     * Stampa debug solo se la modalita' debug e' attiva in config.
+     *
+     * @param msg Messaggio di debug.
+     */
+    private void print(String msg) {
+        if (BedWars.config.getBoolean("debug")) {
+            BedWars.plugin.getLogger().info(msg);
+        }
+    }
+}

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/joinhandler/JoinListenerMultiArena.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/joinhandler/JoinListenerMultiArena.java
@@ -91,7 +91,18 @@ public class JoinListenerMultiArena implements Listener {
         SidebarService.getInstance().giveSidebar(p, null, true);
 
         p.setHealthScale(p.getMaxHealth());
-        p.setExp(0);
+        // BUGFIX: Se il flag xp-bar.show-level è disabilitato, resetta exp a 0 (vanilla behavior)
+        // Se abilitato, lasciarà che il task scheduler mostri il progresso BedWars
+        if (!com.andrei1058.bedwars.configuration.LevelsConfig.isXpBarShowLevelEnabled()) {
+            p.setExp(0);
+        } else {
+            // Schedula con delay per assicurare che PlayerLevel sia già stato creato da LevelListeners
+            Bukkit.getScheduler().runTaskLater(BedWars.plugin, () -> {
+                com.andrei1058.bedwars.levels.internal.PlayerLevel pl = 
+                        com.andrei1058.bedwars.levels.internal.PlayerLevel.getOrNull(p.getUniqueId());
+                if (pl != null) pl.updateXpBar(p);
+            }, 1L);
+        }
         p.setHealthScale(20);
         p.setFoodLevel(20);
     }

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/shop/main/BuyItem.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/shop/main/BuyItem.java
@@ -25,6 +25,7 @@ import com.andrei1058.bedwars.api.arena.IArena;
 import com.andrei1058.bedwars.api.arena.shop.IBuyItem;
 import com.andrei1058.bedwars.api.arena.team.TeamEnchant;
 import com.andrei1058.bedwars.api.configuration.ConfigPath;
+import com.andrei1058.bedwars.listeners.InvisibilityPotionListener;
 import com.andrei1058.bedwars.configuration.Sounds;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -215,8 +216,10 @@ public class BuyItem implements IBuyItem {
             Bukkit.getScheduler().runTaskLater(plugin, () -> {
                 // #274
                 if (player.hasPotionEffect(PotionEffectType.INVISIBILITY)) {
-                    for (Player p : arena.getPlayers()) {
-                        BedWars.nms.hideArmor(player, p);
+                    for (Player p : player.getWorld().getPlayers()) {
+                        if (InvisibilityPotionListener.shouldHideArmorForViewer(arena, player, p)) {
+                            BedWars.nms.hideArmor(player, p);
+                        }
                     }
                 }
                 //

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/sidebar/BwSidebar.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/sidebar/BwSidebar.java
@@ -65,6 +65,14 @@ public class BwSidebar implements ISidebar {
         this.registerPersistentPlaceholder(new PlaceholderProvider("{server}", () -> serverId));
         String serverIp = BedWars.config.getString(ConfigPath.GENERAL_CONFIG_PLACEHOLDERS_REPLACEMENTS_SERVER_IP);
         this.registerPersistentPlaceholder(new PlaceholderProvider("{serverIp}", () -> serverIp));
+        // Always available: total players on server and players in lobby world
+        this.registerPersistentPlaceholder(new PlaceholderProvider("{on}", () ->
+                String.valueOf(Bukkit.getOnlinePlayers().size())));
+        String lobbyWorldName = config.getLobbyWorldName();
+        this.registerPersistentPlaceholder(new PlaceholderProvider("{lobbyOn}", () -> {
+            org.bukkit.World lobbyWorld = Bukkit.getWorld(lobbyWorldName);
+            return null == lobbyWorld ? "0" : String.valueOf(lobbyWorld.getPlayers().size());
+        }));
     }
 
     public void remove() {
@@ -308,14 +316,6 @@ public class BwSidebar implements ISidebar {
         }));
 
         if (hasNoArena()) {
-            providers.add(new PlaceholderProvider("{on}", () ->
-                    String.valueOf(Bukkit.getOnlinePlayers().size()))
-            );
-            String lobbyWorldName = config.getLobbyWorldName();
-            providers.add(new PlaceholderProvider("{lobbyOn}", () -> {
-                org.bukkit.World lobbyWorld = Bukkit.getWorld(lobbyWorldName);
-                return null == lobbyWorld ? "0" : String.valueOf(lobbyWorld.getPlayers().size());
-            }));
             PlayerStats persistentStats = BedWars.getStatsManager().get(player.getUniqueId());
             //noinspection ConstantConditions
             if (null != persistentStats) {
@@ -345,7 +345,7 @@ public class BwSidebar implements ISidebar {
                 );
             }
         } else {
-            providers.add(new PlaceholderProvider("{on}", () -> String.valueOf(arena.getPlayers().size())));
+            providers.add(new PlaceholderProvider("{arenaOn}", () -> String.valueOf(arena.getPlayers().size())));
             providers.add(new PlaceholderProvider("{max}", () -> String.valueOf(arena.getMaxPlayers())));
             providers.add(new PlaceholderProvider("{nextEvent}", this::getNextEventName));
 
@@ -596,10 +596,12 @@ public class BwSidebar implements ISidebar {
 
         }
 
+        ConcurrentLinkedQueue<PlaceholderProvider> tabPlaceholders = getPlaceholders(this.getPlayer());
+        tabPlaceholders.addAll(this.persistentProviders);
         this.headerFooter = new TabHeaderFooter(
                 this.normalizeLines(lang.l(headerPath)),
                 this.normalizeLines(lang.l(footerPath)),
-                getPlaceholders(this.getPlayer())
+                tabPlaceholders
         );
 
         SidebarManager.getInstance().sendHeaderFooter(player, headerFooter);

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/sidebar/BwSidebar.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/sidebar/BwSidebar.java
@@ -311,6 +311,11 @@ public class BwSidebar implements ISidebar {
             providers.add(new PlaceholderProvider("{on}", () ->
                     String.valueOf(Bukkit.getOnlinePlayers().size()))
             );
+            String lobbyWorldName = config.getLobbyWorldName();
+            providers.add(new PlaceholderProvider("{lobbyOn}", () -> {
+                org.bukkit.World lobbyWorld = Bukkit.getWorld(lobbyWorldName);
+                return null == lobbyWorld ? "0" : String.valueOf(lobbyWorld.getPlayers().size());
+            }));
             PlayerStats persistentStats = BedWars.getStatsManager().get(player.getUniqueId());
             //noinspection ConstantConditions
             if (null != persistentStats) {

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/sidebar/BwSidebar.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/sidebar/BwSidebar.java
@@ -235,9 +235,10 @@ public class BwSidebar implements ISidebar {
                     .replace("{version}", plugin.getDescription().getVersion())
                     .replace("{server}", config.getString(ConfigPath.GENERAL_CONFIGURATION_BUNGEE_OPTION_SERVER_ID))
             ;
-
-            // Resolve level-related placeholders directly to avoid first-join timing issues.
-            line = resolveLevelPlaceholders(line);
+            // Level-related placeholders ({level}, {currentXp}, {requiredXp}, {progress}, etc.)
+            // are handled dynamically by PlaceholderProvider entries in getPlaceholders()
+            // and refreshed periodically. Do NOT pre-resolve them here or the PlaceholderProvider
+            // cannot find the placeholder keys and values will be stale.
 
             // Add the line to the sidebar
             String finalTemp = line;

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/sidebar/BwSidebar.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/sidebar/BwSidebar.java
@@ -92,6 +92,13 @@ public class BwSidebar implements ISidebar {
         if (null == handle) {
             handle = SidebarService.getInstance().getSidebarHandler().createSidebar(title, lines, placeholders);
             handle.add(player);
+            Bukkit.getScheduler().runTaskLater(plugin, () -> {
+                if (this.handle != null) {
+                    new ArrayList<>(this.handle.getPlaceholders()).forEach(p -> this.handle.removePlaceholder(p.getPlaceholder()));
+                    placeholders.forEach(this.handle::addPlaceholder);
+                    this.handle.refreshPlaceholders();
+                }
+            }, 2L);
         } else {
             handle.clearLines();
             Bukkit.getScheduler().runTaskLater(plugin, () -> {
@@ -99,6 +106,7 @@ public class BwSidebar implements ISidebar {
                 placeholders.forEach(p -> handle.addPlaceholder(p));
                 handle.setTitle(title);
                 lines.forEach(l -> handle.addLine(l));
+                handle.refreshPlaceholders();
             }, 2L);
         }
         tabList.handlePlayerList();
@@ -111,13 +119,14 @@ public class BwSidebar implements ISidebar {
 
     @SuppressWarnings("ConstantConditions")
     public SidebarLine normalizeTitle(@Nullable List<String> titleArray) {
+        if (null == titleArray || titleArray.isEmpty()) {
+            return EMPTY_TITLE;
+        }
         String[] data = new String[titleArray.size()];
         for (int x = 0; x < titleArray.size(); x++) {
-            data[x] = titleArray.get(x);
+            data[x] = resolveLevelPlaceholders(titleArray.get(x));
         }
-        return null == titleArray || titleArray.isEmpty() ?
-                EMPTY_TITLE :
-                new SidebarLineAnimated(data);
+        return new SidebarLineAnimated(data);
     }
 
     /**
@@ -219,6 +228,9 @@ public class BwSidebar implements ISidebar {
                     .replace("{server}", config.getString(ConfigPath.GENERAL_CONFIGURATION_BUNGEE_OPTION_SERVER_ID))
             ;
 
+            // Resolve level-related placeholders directly to avoid first-join timing issues.
+            line = resolveLevelPlaceholders(line);
+
             // Add the line to the sidebar
             String finalTemp = line;
 
@@ -235,6 +247,16 @@ public class BwSidebar implements ISidebar {
             lines.add(sidebarLine);
         }
         return lines;
+    }
+
+    private @NotNull String resolveLevelPlaceholders(@NotNull String text) {
+        PlayerLevel playerLevel = PlayerLevel.getOrNull(player.getUniqueId());
+        return text
+                .replace("{level}", null == playerLevel ? "1" : String.valueOf(playerLevel.getLevelName()))
+                .replace("{levelUnformatted}", null == playerLevel ? "1" : String.valueOf(playerLevel.getLevel()))
+                .replace("{currentXp}", null == playerLevel ? "0" : playerLevel.getFormattedCurrentXp())
+                .replace("{requiredXp}", null == playerLevel ? "0" : playerLevel.getFormattedRequiredXp())
+                .replace("{progress}", null == playerLevel ? "" : playerLevel.getProgress());
     }
 
     @Override

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/sidebar/BwSidebar.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/sidebar/BwSidebar.java
@@ -264,14 +264,26 @@ public class BwSidebar implements ISidebar {
         // fixme 29/08/2023: disabled for now because this is not a dynamic placeholder. Let's see what's the impact.
 //        providers.add(new PlaceholderProvider("{serverIp}", () -> BedWars.config.getString(ConfigPath.GENERAL_CONFIG_PLACEHOLDERS_REPLACEMENTS_SERVER_IP)));
         providers.add(new PlaceholderProvider("{version}", () -> plugin.getDescription().getVersion()));
-        PlayerLevel level = PlayerLevel.getLevelByPlayer(player.getUniqueId());
-        if (null != level) {
-            providers.add(new PlaceholderProvider("{progress}", level::getProgress));
-            providers.add(new PlaceholderProvider("{level}", () -> String.valueOf(level.getLevelName())));
-            providers.add(new PlaceholderProvider("{levelUnformatted}", () -> String.valueOf(level.getLevel())));
-            providers.add(new PlaceholderProvider("{currentXp}", level::getFormattedCurrentXp));
-            providers.add(new PlaceholderProvider("{requiredXp}", level::getFormattedRequiredXp));
-        }
+        providers.add(new PlaceholderProvider("{progress}", () -> {
+            PlayerLevel level = PlayerLevel.getOrNull(player.getUniqueId());
+            return null == level ? "" : level.getProgress();
+        }));
+        providers.add(new PlaceholderProvider("{level}", () -> {
+            PlayerLevel level = PlayerLevel.getOrNull(player.getUniqueId());
+            return null == level ? "1" : String.valueOf(level.getLevelName());
+        }));
+        providers.add(new PlaceholderProvider("{levelUnformatted}", () -> {
+            PlayerLevel level = PlayerLevel.getOrNull(player.getUniqueId());
+            return null == level ? "1" : String.valueOf(level.getLevel());
+        }));
+        providers.add(new PlaceholderProvider("{currentXp}", () -> {
+            PlayerLevel level = PlayerLevel.getOrNull(player.getUniqueId());
+            return null == level ? "0" : level.getFormattedCurrentXp();
+        }));
+        providers.add(new PlaceholderProvider("{requiredXp}", () -> {
+            PlayerLevel level = PlayerLevel.getOrNull(player.getUniqueId());
+            return null == level ? "0" : level.getFormattedRequiredXp();
+        }));
 
         if (hasNoArena()) {
             providers.add(new PlaceholderProvider("{on}", () ->

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/sidebar/BwTabList.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/sidebar/BwTabList.java
@@ -28,6 +28,7 @@ import com.andrei1058.bedwars.api.configuration.ConfigPath;
 import com.andrei1058.bedwars.api.language.Language;
 import com.andrei1058.bedwars.api.language.Messages;
 import com.andrei1058.bedwars.api.server.ServerType;
+import com.andrei1058.bedwars.levels.internal.PlayerLevel;
 import com.andrei1058.spigot.sidebar.PlayerTab;
 import com.andrei1058.spigot.sidebar.Sidebar;
 import com.andrei1058.spigot.sidebar.SidebarLine;
@@ -377,6 +378,14 @@ public class BwTabList {
                     parsed = parsed.replace(entry.getKey(), entry.getValue());
                 }
             }
+
+            PlayerLevel level = PlayerLevel.getOrNull(targetPlayer.getUniqueId());
+            parsed = parsed
+                    .replace("{level}", null == level ? "1" : String.valueOf(level.getLevelName()))
+                    .replace("{levelUnformatted}", null == level ? "1" : String.valueOf(level.getLevel()))
+                    .replace("{currentXp}", null == level ? "0" : level.getFormattedCurrentXp())
+                    .replace("{requiredXp}", null == level ? "0" : level.getFormattedRequiredXp())
+                    .replace("{progress}", null == level ? "" : level.getProgress());
 
             strings.add(parsed);
         }

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/sidebar/BwTabList.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/sidebar/BwTabList.java
@@ -357,8 +357,8 @@ public class BwTabList {
 
     @NotNull
     private SidebarLine getTabText(String path, Player targetPlayer, @Nullable HashMap<String, String> replacements) {
-        List<String> strings = Language.getList(sidebar.getPlayer(), path);
-        if (strings.isEmpty()) {
+        List<String> rawStrings = Language.getList(sidebar.getPlayer(), path);
+        if (rawStrings.isEmpty()) {
             return new SidebarLine() {
                 @NotNull
                 @Override
@@ -368,8 +368,11 @@ public class BwTabList {
             };
         }
 
-        strings = new ArrayList<>();
-        for (String string : Language.getList(sidebar.getPlayer(), path)) {
+        // Resolve static placeholders (vPrefix, vSuffix, team) at creation time.
+        // Level placeholders are intentionally left unresolved here and handled below.
+        List<String> templates = new ArrayList<>();
+        List<String> staticResolved = new ArrayList<>();
+        for (String string : rawStrings) {
             String parsed = string.replace("{vPrefix}", BedWars.getChatSupport().getPrefix(targetPlayer))
                     .replace("{vSuffix}", BedWars.getChatSupport().getSuffix(targetPlayer));
 
@@ -379,32 +382,40 @@ public class BwTabList {
                 }
             }
 
-            PlayerLevel level = PlayerLevel.getOrNull(targetPlayer.getUniqueId());
-            parsed = parsed
-                    .replace("{level}", null == level ? "1" : String.valueOf(level.getLevelName()))
-                    .replace("{levelUnformatted}", null == level ? "1" : String.valueOf(level.getLevel()))
-                    .replace("{currentXp}", null == level ? "0" : level.getFormattedCurrentXp())
-                    .replace("{requiredXp}", null == level ? "0" : level.getFormattedRequiredXp())
-                    .replace("{progress}", null == level ? "" : level.getProgress());
+            templates.add(parsed);
 
-            strings.add(parsed);
+            // Pre-resolve level for animated frames (fallback for multi-frame entries)
+            PlayerLevel lvl = PlayerLevel.getOrNull(targetPlayer.getUniqueId());
+            staticResolved.add(parsed
+                    .replace("{level}", null == lvl ? "1" : String.valueOf(lvl.getLevelName()))
+                    .replace("{levelUnformatted}", null == lvl ? "1" : String.valueOf(lvl.getLevel()))
+                    .replace("{currentXp}", null == lvl ? "0" : lvl.getFormattedCurrentXp())
+                    .replace("{requiredXp}", null == lvl ? "0" : lvl.getFormattedRequiredXp())
+                    .replace("{progress}", null == lvl ? "" : lvl.getProgress()));
         }
 
-        if (strings.size() == 1) {
-            final String line = strings.get(0);
+        // Single-frame: resolve level dynamically on every getLine() call so TAB
+        // always shows the current level even after another player levels up.
+        if (templates.size() == 1) {
+            final String template = templates.get(0);
             return new SidebarLine() {
                 @NotNull
                 @Override
                 public String getLine() {
-                    return line;
+                    PlayerLevel level = PlayerLevel.getOrNull(targetPlayer.getUniqueId());
+                    return template
+                            .replace("{level}", null == level ? "1" : String.valueOf(level.getLevelName()))
+                            .replace("{levelUnformatted}", null == level ? "1" : String.valueOf(level.getLevel()))
+                            .replace("{currentXp}", null == level ? "0" : level.getFormattedCurrentXp())
+                            .replace("{requiredXp}", null == level ? "0" : level.getFormattedRequiredXp())
+                            .replace("{progress}", null == level ? "" : level.getProgress());
                 }
             };
         }
 
-        final String[] lines = new String[strings.size()];
-        for (int i = 0; i < lines.length; i++) {
-            lines[i] = strings.get(i);
-        }
+        // Animated (multi-frame): use pre-resolved strings.
+        // {level} in animated tab entries is not used in practice.
+        final String[] lines = staticResolved.toArray(new String[0]);
         return new SidebarLineAnimated(lines);
     }
 

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/sidebar/SidebarService.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/sidebar/SidebarService.java
@@ -118,6 +118,11 @@ public class SidebarService implements ISidebarService {
     }
 
     public void giveSidebar(@NotNull Player player, @Nullable IArena arena, boolean delay) {
+        if (delay) {
+            waitForStatsAndGiveSidebar(player, arena, 0);
+            return;
+        }
+
         BwSidebar sidebar = sidebars.getOrDefault(player.getUniqueId(), null);
 
         // check if we might need to remove the existing sidebar
@@ -228,6 +233,28 @@ public class SidebarService implements ISidebarService {
 
         if (newlyAdded) {
             sidebars.put(player.getUniqueId(), sidebar);
+        }
+    }
+
+    /**
+     * Wait for player stats to be loaded before giving the sidebar.
+     * Retries every 2 ticks, up to 100 ticks (5 seconds), to avoid rendering
+     * the sidebar before the async database fetch completes on first login.
+     */
+    private void waitForStatsAndGiveSidebar(@NotNull Player player, @Nullable IArena arena, int attempt) {
+        if (!player.isOnline()) return;
+        if (attempt >= 50) {
+            // Give up waiting after 5 seconds and render whatever we have
+            giveSidebar(player, arena, false);
+            return;
+        }
+        // Stats are loaded in StatsListener#onAsyncPreLoginEvent and stored in StatsManager.
+        // Once present, it's safe to render the sidebar.
+        if (BedWars.getStatsManager().get(player.getUniqueId()) != null) {
+            giveSidebar(player, arena, false);
+        } else {
+            Bukkit.getScheduler().runTaskLater(BedWars.plugin, () ->
+                waitForStatsAndGiveSidebar(player, arena, attempt + 1), 2L);
         }
     }
 

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/sidebar/SidebarService.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/sidebar/SidebarService.java
@@ -288,7 +288,18 @@ public class SidebarService implements ISidebarService {
             if (null != v.getArena()) {
                 v.getHandle().playerHealthRefreshAnimation();
                 for (Player player : v.getArena().getPlayers()) {
-                    v.getHandle().setPlayerHealth(player, (int) Math.ceil(player.getHealth()));
+                    int health = (int) Math.ceil(player.getHealth());
+                    v.getHandle().setPlayerHealth(player, health);
+                    
+                    // FIX [DEBUG] FASE 1 - Aggiornamento periodico vita 
+                    // Forza il pacchetto nativo di Bukkit per la 1.20 perché la libreria sidebar non invia il player.getName()
+                    org.bukkit.scoreboard.Scoreboard sb = v.getPlayer().getScoreboard();
+                    if (sb != null) {
+                        org.bukkit.scoreboard.Objective obj = sb.getObjective(org.bukkit.scoreboard.DisplaySlot.BELOW_NAME);
+                        if (obj != null) {
+                            obj.getScore(player.getName()).setScore(health);
+                        }
+                    }
                 }
             }
         });
@@ -303,6 +314,16 @@ public class SidebarService implements ISidebarService {
         this.sidebars.forEach((k, v) -> {
             if (null != v.getArena() && v.getArena().equals(arena)) {
                 v.getHandle().setPlayerHealth(player, health);
+                
+                // FIX [DEBUG] FASE 2 - Aggiornamento in tempo reale (danni) 
+                // Assicura che la vita sotto al nome venga aggiornata in real-time usando Bukkit API per 1.20+
+                org.bukkit.scoreboard.Scoreboard sb = v.getPlayer().getScoreboard();
+                if (sb != null) {
+                    org.bukkit.scoreboard.Objective obj = sb.getObjective(org.bukkit.scoreboard.DisplaySlot.BELOW_NAME);
+                    if (obj != null) {
+                        obj.getScore(player.getName()).setScore(health);
+                    }
+                }
             }
         });
     }

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.andrei1058.bedwars</groupId>
     <artifactId>BedWars1058</artifactId>
     <packaging>pom</packaging>
-    <version>25.2</version>
+    <version>G25</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>net.md-5</groupId>
             <artifactId>bungeecord-chat</artifactId>
-            <version>1.8-SNAPSHOT</version>
+            <version>1.18-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/commons-io/commons-io -->

--- a/resetadapter_aswm/pom.xml
+++ b/resetadapter_aswm/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>BedWars1058</artifactId>
         <groupId>com.andrei1058.bedwars</groupId>
-        <version>25.2</version>
+        <version>G25</version>
     </parent>
 
     <artifactId>resetadapter-aswm</artifactId>

--- a/resetadapter_slime/pom.xml
+++ b/resetadapter_slime/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>BedWars1058</artifactId>
         <groupId>com.andrei1058.bedwars</groupId>
-        <version>25.2</version>
+        <version>G25</version>
     </parent>
 
     <artifactId>resetadapter-slime</artifactId>

--- a/resetadapter_slimepaper/pom.xml
+++ b/resetadapter_slimepaper/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>BedWars1058</artifactId>
         <groupId>com.andrei1058.bedwars</groupId>
-        <version>25.2</version>
+        <version>G25</version>
     </parent>
 
     <artifactId>resetadapter-slimepaper</artifactId>

--- a/versionsupport_1_12_R1/pom.xml
+++ b/versionsupport_1_12_R1/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>BedWars1058</artifactId>
         <groupId>com.andrei1058.bedwars</groupId>
-        <version>25.2</version>
+        <version>G25</version>
     </parent>
 
     <dependencies>

--- a/versionsupport_1_8_R3/pom.xml
+++ b/versionsupport_1_8_R3/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>BedWars1058</artifactId>
         <groupId>com.andrei1058.bedwars</groupId>
-        <version>25.2</version>
+        <version>G25</version>
     </parent>
 
     <artifactId>versionsupport_1_8_R3</artifactId>

--- a/versionsupport_common/pom.xml
+++ b/versionsupport_common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>BedWars1058</artifactId>
         <groupId>com.andrei1058.bedwars</groupId>
-        <version>25.2</version>
+        <version>G25</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/versionsupport_v1_16_R3/pom.xml
+++ b/versionsupport_v1_16_R3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>BedWars1058</artifactId>
         <groupId>com.andrei1058.bedwars</groupId>
-        <version>25.2</version>
+        <version>G25</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/versionsupport_v1_17_R1/pom.xml
+++ b/versionsupport_v1_17_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>BedWars1058</artifactId>
         <groupId>com.andrei1058.bedwars</groupId>
-        <version>25.2</version>
+        <version>G25</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/versionsupport_v1_18_R2/pom.xml
+++ b/versionsupport_v1_18_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>BedWars1058</artifactId>
         <groupId>com.andrei1058.bedwars</groupId>
-        <version>25.2</version>
+        <version>G25</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/versionsupport_v1_19_R2/pom.xml
+++ b/versionsupport_v1_19_R2/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.andrei1058.bedwars</groupId>
         <artifactId>BedWars1058</artifactId>
-        <version>25.2</version>
+        <version>G25</version>
     </parent>
 
     <artifactId>versionsupport_v1_19_R2</artifactId>

--- a/versionsupport_v1_19_R3/pom.xml
+++ b/versionsupport_v1_19_R3/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.andrei1058.bedwars</groupId>
         <artifactId>BedWars1058</artifactId>
-        <version>25.2</version>
+        <version>G25</version>
     </parent>
 
     <artifactId>versionsupport_v1_19_R3</artifactId>

--- a/versionsupport_v1_20_R1/pom.xml
+++ b/versionsupport_v1_20_R1/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.andrei1058.bedwars</groupId>
         <artifactId>BedWars1058</artifactId>
-        <version>25.2</version>
+        <version>G25</version>
     </parent>
 
     <artifactId>versionsupport_v1_20_R1</artifactId>

--- a/versionsupport_v1_20_R2/pom.xml
+++ b/versionsupport_v1_20_R2/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.andrei1058.bedwars</groupId>
         <artifactId>BedWars1058</artifactId>
-        <version>25.2</version>
+        <version>G25</version>
     </parent>
 
     <artifactId>versionsupport_v1_20_R2</artifactId>

--- a/versionsupport_v1_20_R3/pom.xml
+++ b/versionsupport_v1_20_R3/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.andrei1058.bedwars</groupId>
         <artifactId>BedWars1058</artifactId>
-        <version>25.2</version>
+        <version>G25</version>
     </parent>
 
     <artifactId>versionsupport_v1_20_R3</artifactId>

--- a/versionsupport_v1_20_R3/src/main/java/com/andrei1058/bedwars/support/version/v1_20_R3/v1_20_R3.java
+++ b/versionsupport_v1_20_R3/src/main/java/com/andrei1058/bedwars/support/version/v1_20_R3/v1_20_R3.java
@@ -285,11 +285,14 @@ public class v1_20_R3 extends VersionSupport {
 
     @Override
     public void hideArmor(@NotNull Player victim, Player receiver) {
+        // FIX [DEBUG] FASE 1 - In 1.20.4, CraftItemStack.asNMSCopy(null) ritorna ItemStack.EMPTY (ItemStack.b natively)
+        // che e' l'unico modo sicuro per far credere al client che lo slot sia veramente vuoto senza causare glitch.
         List<Pair<EnumItemSlot, ItemStack>> items = new ArrayList<>();
-        items.add(new Pair<>(EnumItemSlot.f, new ItemStack(Item.b(0))));
-        items.add(new Pair<>(EnumItemSlot.e, new ItemStack(Item.b(0))));
-        items.add(new Pair<>(EnumItemSlot.d, new ItemStack(Item.b(0))));
-        items.add(new Pair<>(EnumItemSlot.c, new ItemStack(Item.b(0))));
+        ItemStack emptyStack = CraftItemStack.asNMSCopy(null);
+        items.add(new Pair<>(EnumItemSlot.f, emptyStack));
+        items.add(new Pair<>(EnumItemSlot.e, emptyStack));
+        items.add(new Pair<>(EnumItemSlot.d, emptyStack));
+        items.add(new Pair<>(EnumItemSlot.c, emptyStack));
         PacketPlayOutEntityEquipment packet1 = new PacketPlayOutEntityEquipment(victim.getEntityId(), items);
         sendPacket(receiver, packet1);
     }

--- a/versionsupport_v1_20_R4/pom.xml
+++ b/versionsupport_v1_20_R4/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.andrei1058.bedwars</groupId>
         <artifactId>BedWars1058</artifactId>
-        <version>25.2</version>
+        <version>G25</version>
     </parent>
 
     <artifactId>versionsupport_v1_20_R4</artifactId>


### PR DESCRIPTION
This PR introduces full compatibility for Minecraft 1.20.5, addresses several critical NMS-related bugs, and implements a major overhaul of the placeholder and spectator systems.

**Core Updates and 1.20.5 Support**
Version Compatibility: Implemented native support for Minecraft 1.20.5.

- NMS Fixes: Resolved NMS issues for versions 1.20.3 through 1.20.5, specifically regarding Itemstack handling and Sidebar/HP desynchronization;
- Armor Glitch: Fixed the critical issue causing armor invisibility (Issue #1128);
- Database: Fixed the "Ghost Level" bug by implementing asynchronous login checks (Issue #907);
- Placeholder and Tab System Refactor;
- Persistent Placeholders: Moved {on} (total server players) and {lobbyOn} to persistent registration. They are now resolvable in all game phases, including waiting, starting, playing, and restarting;
- Placeholder Renaming: To prevent collisions with the global {on} placeholder, the in-game arena player count has been renamed to {arenaOn}.
- Tab Header/Footer Fix: Fixed a bug in assignTabHeaderFooter where persistent providers were excluded from the queue, causing {on} and {serverIp} to fail rendering;
- Reliability: Resolved intermittent rendering issues for level, XP, and first-login placeholders across the sidebar and tab list;

**New Features and Mechanics**
- TNT Countdown: Added a dynamic visual countdown on primed TNT;
- Quick Deposit: Implemented a new mechanic allowing players to quick-deposit items into team chests via right-click;
- Invisibility Footsteps: Added configurable native footsteps for invisible players using ProtocolLib;
- Split Generators: Implemented an advanced generator system featuring vector-based animations;
- XP Bar Persistence: The XP bar now consistently tracks and displays the BedWars level.

**Spectator and End-Game Flow**
Configurable Flow: Added comprehensive configuration options for the post-game sequence, including:
- Forced spectator mode before lobby teleportation.
- Customizable game modes for players and spectators.
- Spectator visibility in the tab list and transparency levels.
- Automatic chat clearing at the end of a match.

Refactoring: Replaced remaining hardcoded game mode transitions with configuration-backed values to ensure consistency with the arena rejoin flow.

**Technical Maintenance**
Cleaned up pom.xml and updated bStats and Sidebar API dependencies.

Verified stability across Minecraft versions 1.20.x through 1.20.5.

Important Note for Users
The placeholder for the current arena player count has changed from {on} to {arenaOn}. Configuration files using {on} for specific arena counts must be updated to avoid displaying the total server player count instead.