### PR TITLE
Fix common gameplay edge cases

### DIFF
--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/BreakPlace.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/BreakPlace.java
@@ -213,9 +213,16 @@ public class BreakPlace implements Listener {
     @EventHandler(ignoreCancelled = true)
     public void onInteract(PlayerInteractEvent event) {
         Player player = event.getPlayer();
+        if (event.getClickedBlock() != null && isFire(event.getClickedBlock().getType())) {
+            IArena arena = Arena.getArenaByPlayer(player);
+            if (arena != null && !allowFireBreak) {
+                event.setCancelled(true);
+                return;
+            }
+        }
         if (BedWars.getServerType() == ServerType.MULTIARENA
                 && player.getWorld().getName().equalsIgnoreCase(BedWars.getLobbyWorld())) {
-            if (event.getClickedBlock() != null && event.getClickedBlock().getRelative(BlockFace.UP).getType() == Material.FIRE) {
+            if (event.getClickedBlock() != null && isFire(event.getClickedBlock().getRelative(BlockFace.UP).getType())) {
                 if (!isBuildSession(player)) {
                     event.setCancelled(true);
                     //return;
@@ -286,6 +293,7 @@ public class BreakPlace implements Listener {
                     }
                     return;
                 case "FIRE":
+                case "SOUL_FIRE":
                     if (allowFireBreak) {
                         e.setCancelled(false);
                         return;
@@ -368,6 +376,7 @@ public class BreakPlace implements Listener {
                 if (!a.isBlockPlaced(e.getBlock())) {
                     p.sendMessage(getMsg(p, Messages.INTERACT_CANNOT_BREAK_BLOCK));
                     e.setCancelled(true);
+                    return;
                 }
             }
         }
@@ -621,5 +630,10 @@ public class BreakPlace implements Listener {
 
     public static void removeBuildSession(Player p) {
         buildSession.remove(p);
+    }
+
+    private static boolean isFire(Material material) {
+        String name = material.toString();
+        return name.equals("FIRE") || name.equals("SOUL_FIRE");
     }
 }

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/DamageDeathMove.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/DamageDeathMove.java
@@ -333,11 +333,17 @@ public class DamageDeathMove implements Listener {
             e.setDeathMessage(null);
         }
         if (a != null) {
+            e.setDroppedExp(0);
+            e.setNewExp(0);
+            e.setNewLevel(0);
+            e.setNewTotalExp(0);
             if (a.isSpectator(victim)) {
+                e.getDrops().clear();
                 victim.spigot().respawn();
                 return;
             }
             if (a.getStatus() != GameState.playing) {
+                e.getDrops().clear();
                 victim.spigot().respawn();
                 return;
             }
@@ -345,10 +351,12 @@ public class DamageDeathMove implements Listener {
 
             ITeam victimsTeam = a.getTeam(victim);
             if (a.getStatus() != GameState.playing) {
+                e.getDrops().clear();
                 victim.spigot().respawn();
                 return;
             }
             if (victimsTeam == null) {
+                e.getDrops().clear();
                 victim.spigot().respawn();
                 return;
             }

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/dropshandler/PlayerDrops.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/listeners/dropshandler/PlayerDrops.java
@@ -94,7 +94,8 @@ public class PlayerDrops {
                     if (i == null) continue;
                     if (i.getType() == Material.AIR) continue;
                     if (nms.isArmor(i) || nms.isBow(i) || nms.isSword(i) || nms.isTool(i)) continue;
-                    if (!nms.getShopUpgradeIdentifier(i).trim().isEmpty()) continue;
+                    String identifier = nms.getShopUpgradeIdentifier(i);
+                    if (identifier != null && !identifier.trim().isEmpty()) continue;
                     if (arena.getTeam(killer) != null) {
                         Vector v = victimsTeam.getKillDropsLocation();
                         killer.getWorld().dropItemNaturally(new Location(arena.getWorld(), v.getX(), v.getY(), v.getZ()), i);

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/shop/ShopCache.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/shop/ShopCache.java
@@ -130,7 +130,7 @@ public class ShopCache {
             for (ItemStack i : p.getInventory().getContents()) {
                 if (i == null) continue;
                 if (i.getType() == Material.AIR) continue;
-                if (BedWars.nms.getShopUpgradeIdentifier(i).equals(cc.getIdentifier())) {
+                if (cc.getIdentifier().equals(BedWars.nms.getShopUpgradeIdentifier(i))) {
                     p.getInventory().remove(i);
                 }
             }

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/shop/listeners/PlayerDropListener.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/shop/listeners/PlayerDropListener.java
@@ -48,7 +48,7 @@ public class PlayerDropListener implements Listener {
     @EventHandler
     //Prevent from moving items in chests
     public void onClose(InventoryCloseEvent e) {
-        if (!(e instanceof Player)) return;
+        if (!(e.getPlayer() instanceof Player)) return;
         IArena a = Arena.getArenaByPlayer((Player) e.getPlayer());
         if (a == null) return;
         String identifier;
@@ -56,6 +56,7 @@ public class PlayerDropListener implements Listener {
             if (i == null) continue;
             if (i.getType() == Material.AIR) continue;
             identifier = BedWars.nms.getShopUpgradeIdentifier(i);
+            if (identifier == null) return;
             if (identifier.isEmpty() || identifier.equals(" ")) return;
         }
     }

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/shop/main/BuyItem.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/shop/main/BuyItem.java
@@ -178,6 +178,9 @@ public class BuyItem implements IBuyItem {
 
         ItemStack i = itemStack.clone();
         BedWars.debug("Giving BuyItem: " + getUpgradeIdentifier() + " to: " + player.getName());
+        if (i.getType() == Material.AIR) {
+            return;
+        }
 
         if (autoEquip && nms.isArmor(itemStack)) {
             Material m = i.getType();

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/sidebar/BwTabList.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/sidebar/BwTabList.java
@@ -455,20 +455,26 @@ public class BwTabList {
     }
 
     @SuppressWarnings("unused")
-    private @NotNull String getPlayerTabIdentifierAliveInTeam(ITeam team, Player player) {
+    private @NotNull String getPlayerTabIdentifierAliveInTeam(@Nullable ITeam team, Player player) {
         return getPlayerTabIdentifierAliveInTeam(team, getCreatePlayerTabIdentifier(player));
     }
 
-    private @NotNull String getPlayerTabIdentifierAliveInTeam(ITeam team, String playerId) {
+    private @NotNull String getPlayerTabIdentifierAliveInTeam(@Nullable ITeam team, String playerId) {
+        if (team == null) {
+            return getPlayerTabIdentifierSpectator(null, playerId);
+        }
         return getCreateTeamTabOrderPrefix(team) + playerId;
     }
 
     @SuppressWarnings("unused")
-    private @NotNull String getPlayerTabIdentifierEliminatedInTeam(ITeam team, Player player) {
+    private @NotNull String getPlayerTabIdentifierEliminatedInTeam(@Nullable ITeam team, Player player) {
         return getPlayerTabIdentifierEliminatedInTeam(team, getCreatePlayerTabIdentifier(player));
     }
 
-    private @NotNull String getPlayerTabIdentifierEliminatedInTeam(ITeam team, String playerId) {
+    private @NotNull String getPlayerTabIdentifierEliminatedInTeam(@Nullable ITeam team, String playerId) {
+        if (team == null) {
+            return SPECTATOR_PREFIX + playerId;
+        }
         return ELIMINATED_FROM_TEAM_PREFIX + getCreateTeamTabOrderPrefix(team) + playerId;
     }
 
@@ -488,7 +494,7 @@ public class BwTabList {
         HashMap<String, String> replacements = new HashMap<>();
         String displayName = null == team ? "" : team.getDisplayName(Language.getPlayerLanguage(sidebar.getPlayer()));
         replacements.put("{teamName}", displayName);
-        replacements.put("{teamLetter}", null == team ? "" : team.getColor().chat() + (displayName.substring(0, 1)));
+        replacements.put("{teamLetter}", null == team || displayName.isEmpty() ? "" : team.getColor().chat() + (displayName.substring(0, 1)));
         replacements.put("{teamColor}", null == team ? "" : team.getColor().chat().toString());
 
         return replacements;


### PR DESCRIPTION
## Summary
- guard shop upgrade identifiers before trimming/comparing them during death drops and shop cache updates
- allow AIR buy-items to complete purchase flow without trying to process them as physical items
- clear vanilla XP/drops for BedWars arena death paths that immediately respawn the player
- tolerate missing team data while rebuilding tab-list entries during rejoin
- protect FIRE/SOUL_FIRE interactions in arenas without directly referencing newer Material enum constants
- fix InventoryCloseEvent player detection in permanent-item movement protection

## Related issues
Addresses #1100, #1103, #1123, #1085, and part of #1126.

## Verification
- `git diff --check`
- Attempted `mvn -B -DskipTests package -s ci_settings.xml`, but the current upstream dependency set fails before compiling these changes because `com.andrei1058.spigot.sidebar:sidebar-base:23.2` cannot be resolved from the configured repositories.